### PR TITLE
Add physics simulation enhancements and refactor code

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Transform.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Transform.h
@@ -37,6 +37,7 @@ struct FTransform
     void SetRotation(const FQuat& InRotation) { Rotation = InRotation; }
     
     // 위치 관련 함수들
+    FVector GetLocation() const { return Translation; }
     FVector GetTranslation() const { return Translation; }
     void SetTranslation(const FVector& InTranslation) { Translation = InTranslation; }
     void AddToTranslation(const FVector& InTranslation) { Translation += InTranslation; }
@@ -63,7 +64,7 @@ struct FTransform
     
     void Blend(const FTransform& Atom1, const FTransform& Atom2, float Alpha);
     FTransform BlendWith(const FTransform& Other, float Alpha) const;
-    
+
     // 선형 보간 함수
     static FTransform LerpTransform(const FTransform& A, const FTransform& B, float Alpha);
     

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -923,6 +923,15 @@ void FUnresolvedPtrProperty::DisplayInImGui(UObject* Object) const
     ResolvedProperty->DisplayInImGui(Object);
 }
 
+void FUnresolvedPtrProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+{
+    if (Type == EPropertyType::Unknown)
+    {
+        return;
+    }
+    ResolvedProperty->DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+}
+
 void UMaterialProperty::DisplayInImGui(UObject* Object) const
 {
     ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.h
@@ -18,7 +18,9 @@ public:
 
     virtual void InitializeComponent() override;
     virtual void TickComponent(float DeltaTime) override;
-    
+
+    virtual void PhysicsTick();
+
     bool IntersectRayTriangle(
         const FVector& RayOrigin, const FVector& RayDirection,
         const FVector& v0, const FVector& v1, const FVector& v2, float& OutHitDistance
@@ -26,7 +28,10 @@ public:
 
     virtual void GetProperties(TMap<FString, FString>& OutProperties) const override;
     virtual void SetProperties(const TMap<FString, FString>& InProperties) override;
-    
+
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
     FBoundingBox AABB;
 
     bool GetGenerateOverlapEvents() const { return bGenerateOverlapEvents; }
@@ -103,6 +108,21 @@ public:
         EditAnywhere | LuaReadOnly, ({ .Category = "Collision" }),
         FBodyInstance, BodyInstance, ;
     )
+
+    // 이 컴포넌트가 물리 시뮬레이션을 할지 여부
+    UPROPERTY(
+        EditAnywhere | LuaReadWrite, { .Category = "Physics" },
+        bool, bSimulatePhysics, ;
+    )
+
+    // 물리 상태 생성 및 파괴 가상 함수
+    virtual bool ShouldCreatePhysicsState() const;
+    virtual void CreatePhysicsState();
+    virtual void DestroyPhysicsState();
+    virtual void RecreatePhysicsState(); // 물리 상태 재생성
+
+    // 파생 클래스에서 구현
+    virtual UBodySetup* GetBodySetup() const { return nullptr; }
 
 protected:
     TArray<FOverlapInfo> OverlappingComponents;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.h
@@ -46,7 +46,10 @@ public:
     void SetRelativeRotation(const FQuat& InQuat);
     void SetRelativeScale3D(const FVector& InScale) { RelativeScale3D = InScale; }
     void SetRelativeTransform(const FTransform& InTransform);
-    
+
+    void SetRelativeLocationAndRotation(const FVector& NewLocation, const FRotator& NewRotation);
+    void SetRelativeLocationAndRotation(const FVector& NewLocation, const FQuat& NewRotation);
+
     FVector GetRelativeLocation() const { return RelativeLocation; }
     FRotator GetRelativeRotation() const { return RelativeRotation; }
     FVector GetRelativeScale3D() const { return RelativeScale3D; }
@@ -58,7 +61,10 @@ public:
     
     void SetWorldScale3D(const FVector& InScale);
     void SetWorldTransform(const FTransform& InTransform);
-    
+
+    void SetWorldLocationAndRotation(const FVector& NewLocation, const FRotator& NewRotation);
+    void SetWorldLocationAndRotation(const FVector& NewLocation, const FQuat& NewRotation);
+
     FVector GetComponentLocation() const;
     FRotator GetComponentRotation() const;
     FVector GetComponentScale3D() const;
@@ -74,8 +80,6 @@ public:
 
     bool MoveComponent(const FVector& Delta, const FQuat& NewRotation, bool bSweep, FHitResult* OutHit = nullptr);
     bool MoveComponent(const FVector& Delta, const FRotator& NewRotation, bool bSweep, FHitResult* OutHit = nullptr);
-
-    FTransform GetComponentToWorld() const { return ComponentToWorld; }
 
 protected:
     /** 부모 컴포넌트로부터 상대적인 위치 */
@@ -109,6 +113,4 @@ protected:
 private:
     // TODO: 캐싱해서 사용하기
     bool bComponentToWorldUpdated = true;
-
-    FTransform ComponentToWorld;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.h
@@ -33,6 +33,7 @@ public:
     virtual UObject* Duplicate(UObject* InOuter) override;
 
     virtual void TickComponent(float DeltaTime) override;
+    virtual void PhysicsTick() override;
 
     virtual void TickPose(float DeltaTime) override;
 
@@ -129,6 +130,16 @@ public:
 
     /** Array of FConstraintInstance structs, storing per-instance state about each constraint. */
     TArray<FConstraintInstance*> Constraints;
+
+    // 물리 상태 생성/파괴
+    virtual void CreatePhysicsState() override;
+    virtual void DestroyPhysicsState() override;
+
+protected:
+    void ClearPhysicsState();
+    void InstantiatePhysicsAsset();
+
+    void SyncBodiesToBones();
 
 private:
     FPoseContext BonePoseContext;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/StaticMeshComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/StaticMeshComponent.h
@@ -45,7 +45,13 @@ public:
         }
     }
 
+    virtual UBodySetup* GetBodySetup() const override { return StaticMesh ? StaticMesh->GetBodySetup() : nullptr; }
+
 protected:
-    UStaticMesh* StaticMesh = nullptr;
+    UPROPERTY(
+        EditAnywhere | EditInline,
+        UStaticMesh*, StaticMesh, = nullptr;
+    )
+
     int SelectedSubMeshIndex = -1;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/StaticMesh.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/StaticMesh.cpp
@@ -2,8 +2,14 @@
 #include "Engine/FObjLoader.h"
 #include "UObject/Casts.h"
 #include "UObject/ObjectFactory.h"
-
+#include "PhysicsEngine/BodySetup.h"
 #include "Engine/Asset/StaticMeshAsset.h"
+
+
+UStaticMesh::UStaticMesh()
+{
+    BodySetup = FObjectFactory::ConstructObject<UBodySetup>(this);
+}
 
 UObject* UStaticMesh::Duplicate(UObject* InOuter)
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/StaticMesh.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/StaticMesh.h
@@ -12,7 +12,7 @@ class UStaticMesh : public UObject
     DECLARE_CLASS(UStaticMesh, UObject)
 
 public:
-    UStaticMesh() = default;
+    UStaticMesh();
 
     virtual UObject* Duplicate(UObject* InOuter) override;
 
@@ -43,7 +43,7 @@ private:
     TArray<FStaticMaterial*> Materials;
 
     UPROPERTY(
-        EditAnywhere | Transient | DuplicateTransient, { .Category = "StaticMesh" },
+        EditAnywhere | EditInline | Transient | DuplicateTransient, { .Category = "StaticMesh" },
         UBodySetup*, BodySetup, = nullptr;
     )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocation.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocation.cpp
@@ -38,12 +38,12 @@ void UParticleModuleLocation::Spawn(FParticleEmitterInstance* Owner, int32 Offse
 
     if (bInWorldSpace)
     {
-        Location = Owner->Component->GetComponentToWorld().TransformPosition(Location);
+        Location = Owner->Component->GetComponentTransform().TransformPosition(Location);
     }
 
     if (bApplyEmitterLocation)
     {
-        Location += Owner->Component->GetComponentToWorld().GetTranslation();
+        Location += Owner->Component->GetComponentTransform().GetTranslation();
     }
 
     ParticleBase->Location = Location;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocity.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocity.cpp
@@ -33,19 +33,19 @@ void UParticleModuleVelocity::Spawn(FParticleEmitterInstance* Owner, int32 Offse
 
     if (!FMath::IsNearlyZero(RadialStrength))
     {
-        FVector EmitterLocation = Owner->Component->GetComponentToWorld().GetTranslation();
+        FVector EmitterLocation = Owner->Component->GetComponentTransform().GetTranslation();
         FVector Direction = (ParticleBase->Location - EmitterLocation).GetSafeNormal();
         Velocity += Direction * RadialStrength;
     }
 
     if (bInWorldSpace)
     {
-        Velocity = Owner->Component->GetComponentToWorld().TransformVector(Velocity);
+        Velocity = Owner->Component->GetComponentTransform().TransformVector(Velocity);
     }
 
     if (bApplyOwnerScale)
     {
-        Velocity *= Owner->Component->GetComponentToWorld().GetScale3D();
+        Velocity *= Owner->Component->GetComponentTransform().GetScale3D();
     }
 
     ParticleBase->BaseVelocity = Velocity;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityOverLife.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityOverLife.cpp
@@ -84,11 +84,11 @@ void UParticleModuleVelocityOverLife::Update(FParticleEmitterInstance* Owner, in
     // 월드공간 변환 및 오너 스케일 적용
     if (bInWorldSpace)
     {
-        NewVelocity = Owner->Component->GetComponentToWorld().TransformVector(NewVelocity);
+        NewVelocity = Owner->Component->GetComponentTransform().TransformVector(NewVelocity);
     }
     if (bApplyOwnerScale)
     {
-        NewVelocity *= Owner->Component->GetComponentToWorld().GetScale3D();
+        NewVelocity *= Owner->Component->GetComponentTransform().GetScale3D();
     }
 
     Particle.BaseVelocity = NewVelocity;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/AggregateGeom.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/AggregateGeom.h
@@ -22,25 +22,25 @@ public:
 public:
     // 구체 콜리전
     UPROPERTY(
-        EditAnywhere | EditFixedSize, ({ .Category = "Aggregate Geometry", .DisplayName = "Spheres" }),
+        EditAnywhere /*| EditFixedSize*/, ({ .Category = "Aggregate Geometry", .DisplayName = "Spheres" }),
         TArray<FKSphereElem>, SphereElems, ;
     )
 
     // 박스 콜리전
     UPROPERTY(
-        EditAnywhere | EditFixedSize, ({ .Category = "Aggregate Geometry", .DisplayName = "Boxes" }),
+        EditAnywhere /*| EditFixedSize*/, ({ .Category = "Aggregate Geometry", .DisplayName = "Boxes" }),
         TArray<FKBoxElem>, BoxElems, ;
     )
 
     // 캡슐 콜리전
     UPROPERTY(
-        EditAnywhere | EditFixedSize, ({ .Category = "Aggregate Geometry", .DisplayName = "Capsules" }),
+        EditAnywhere /*| EditFixedSize*/, ({ .Category = "Aggregate Geometry", .DisplayName = "Capsules" }),
         TArray<FKSphylElem>, SphylElems, ;
     )
 
     // 컨벡스 콜리전
     UPROPERTY(
-        EditAnywhere | EditFixedSize, ({ .Category = "Aggregate Geometry", .DisplayName = "Convex Elements" }),
+        EditAnywhere /*| EditFixedSize*/, ({ .Category = "Aggregate Geometry", .DisplayName = "Convex Elements" }),
         TArray<FKConvexElem>, ConvexElems, ;
     )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
@@ -1,0 +1,461 @@
+﻿// ReSharper disable CppMemberFunctionMayBeConst
+// ReSharper disable CppClangTidyCppcoreguidelinesProTypeStaticCastDowncast
+#include "BodyInstance.h"
+
+#include "BodySetup.h"
+#include "PxPhysicsAPI.h"
+#include "Components/PrimitiveComponent.h"
+#include "extensions/PxRigidBodyExt.h"
+
+using namespace physx;
+
+extern PxFoundation* GFoundation;
+extern PxPhysics* GPhysics;
+extern PxDefaultCpuDispatcher* GDispatcher;
+extern PxScene* GScene;
+extern PxMaterial* GMaterial;
+
+struct FKSphereElem;
+struct FKBoxElem;
+struct FKSphylElem;
+struct FKConvexElem;
+
+
+struct FBodyInstance::FBodyInstancePImpl
+{
+    PxRigidActor* RigidActor;
+    void* UserData;
+
+    // 현재 물리 시뮬레이션 여부
+    bool bIsSimulatingPhysics;
+
+    FBodyInstancePImpl()
+        : RigidActor(nullptr)
+        , UserData(nullptr)
+        , bIsSimulatingPhysics(false)
+    {
+    }
+
+    ~FBodyInstancePImpl()
+    {
+        if (RigidActor)
+        {
+            RigidActor->release();
+            RigidActor = nullptr;
+        }
+    }
+
+    // UBodySetup의 FKAggregateGeom 정보를 바탕으로 PxShape들을 생성하고 PxRigidActor에 붙입니다.
+    void CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRigidActor* OutActor);
+
+    PxShape* CreateShapeFromSphere(const FKSphereElem& SphereElem, const PxMaterial& Material) const;
+    PxShape* CreateShapeFromBox(const FKBoxElem& BoxElem, const PxMaterial& Material) const;
+    PxShape* CreateShapeFromSphyl(const FKSphylElem& SphylElem, const PxMaterial& Material) const;
+    PxShape* CreateShapeFromConvex(const FKConvexElem& ConvexElem, const PxMaterial& Material) const;
+};
+
+void FBodyInstance::FBodyInstancePImpl::CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRigidActor* OutActor)
+{
+    if (!(BodySetupRef && RigidActor && GMaterial))
+    {
+        return;
+    }
+
+    const FKAggregateGeom& AggGeom = BodySetupRef->AggGeom;
+
+    for (const FKSphereElem& SphereElem : AggGeom.SphereElems)
+    {
+        if (PxShape* Shape = CreateShapeFromSphere(SphereElem, *GMaterial))
+        {
+            OutActor->attachShape(*Shape);
+            Shape->release();
+        }
+    }
+
+    for (const FKBoxElem& BoxElem : AggGeom.BoxElems)
+    {
+        if (PxShape* Shape = CreateShapeFromBox(BoxElem, *GMaterial))
+        {
+            OutActor->attachShape(*Shape);
+            Shape->release();
+        }
+    }
+
+    for (const FKSphylElem& SphylElem : AggGeom.SphylElems)
+    {
+        if (PxShape* Shape = CreateShapeFromSphyl(SphylElem, *GMaterial))
+        {
+            OutActor->attachShape(*Shape);
+            Shape->release();
+        }
+    }
+
+    for (const FKConvexElem& ConvexElem : AggGeom.ConvexElems)
+    {
+        if (PxShape* Shape = CreateShapeFromConvex(ConvexElem, *GMaterial))
+        {
+            OutActor->attachShape(*Shape);
+            Shape->release();
+        }
+    }
+}
+
+PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromSphere(const FKSphereElem& SphereElem, const PxMaterial& Material) const
+{
+    PxShape* Shape = GPhysics->createShape(
+        PxSphereGeometry(SphereElem.Radius), Material, true, PxShapeFlag::eSIMULATION_SHAPE | PxShapeFlag::eSCENE_QUERY_SHAPE
+    );
+
+    if (Shape)
+    {
+        const PxTransform LocalPose{PxVec3{SphereElem.Center.X, SphereElem.Center.Y, SphereElem.Center.Z}};
+        Shape->setLocalPose(LocalPose);
+    }
+
+    return Shape;
+}
+
+PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromBox(const FKBoxElem& BoxElem, const PxMaterial& Material) const
+{
+    PxShape* Shape = GPhysics->createShape(
+        PxBoxGeometry(BoxElem.X, BoxElem.Y, BoxElem.Z), // 박스 지오메트리 (Half-Extents)
+        Material,
+        true,
+        PxShapeFlag::eSIMULATION_SHAPE | PxShapeFlag::eSCENE_QUERY_SHAPE
+    );
+
+    if (Shape)
+    {
+        const FQuat EngineQuat = BoxElem.Rotation.Quaternion();
+        const PxQuat PxQuatRotation{EngineQuat.X, EngineQuat.Y, EngineQuat.Z, EngineQuat.W};
+        const PxTransform LocalPose{
+            PxVec3{BoxElem.Center.X, BoxElem.Center.Y, BoxElem.Center.Z},
+            PxQuatRotation
+        };
+        Shape->setLocalPose(LocalPose);
+    }
+    return Shape;
+}
+
+PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromSphyl(const FKSphylElem& SphylElem, const PxMaterial& Material) const
+{
+    PxShape* Shape = GPhysics->createShape(
+        PxCapsuleGeometry(SphylElem.Radius, SphylElem.Length / 2.0f), // 캡슐 지오메트리
+        Material,
+        true,
+        PxShapeFlag::eSIMULATION_SHAPE | PxShapeFlag::eSCENE_QUERY_SHAPE
+    );
+
+    if (Shape)
+    {
+        const FQuat EngineQuat = SphylElem.Rotation.Quaternion();
+        // PhysX 캡슐은 X축 기준이므로, 필요시 엔진 좌표계에 맞춰 추가 회전 적용
+        // 예: EngineQuat = EngineQuat * FQuat(FVector::UpVector, -PI / 2.0f) * FQuat(FVector::RightVector, PI / 2.0f);
+
+        const PxQuat PxQuatRotation(EngineQuat.X, EngineQuat.Y, EngineQuat.Z, EngineQuat.W);
+        const PxTransform LocalPose(
+            PxVec3(SphylElem.Center.X, SphylElem.Center.Y, SphylElem.Center.Z),
+            PxQuatRotation
+        );
+        Shape->setLocalPose(LocalPose);
+    }
+    return Shape;
+}
+
+PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromConvex(const FKConvexElem& ConvexElem, const PxMaterial& Material) const
+{
+    return nullptr;
+}
+
+FBodyInstance::FBodyInstance()
+    : OwnerComponent(nullptr)
+    , PImpl(std::make_unique<FBodyInstancePImpl>())
+{
+}
+
+FBodyInstance::~FBodyInstance()
+{
+    TermBody();
+    PImpl.reset();
+}
+
+FBodyInstance::FBodyInstance(FBodyInstance&& Other) noexcept
+    : OwnerComponent(Other.OwnerComponent)
+    , PImpl(std::move(Other.PImpl))
+{
+    Other.OwnerComponent = nullptr;
+    Other.PImpl = nullptr;
+}
+
+FBodyInstance& FBodyInstance::operator=(FBodyInstance&& Other) noexcept
+{
+    if (this != &Other)
+    {
+        PImpl = std::move(Other.PImpl);
+        OwnerComponent = Other.OwnerComponent;
+
+        Other.PImpl = nullptr;
+        Other.OwnerComponent = nullptr;
+    }
+    return *this;
+}
+
+void FBodyInstance::InitBody(
+    UPrimitiveComponent* InOwnerComponent, const UBodySetup* InBodySetup, const FTransform& InTransform, bool bInSimulatePhysics
+)
+{
+    if (!(PImpl && GPhysics && GScene && GMaterial && InBodySetup && InOwnerComponent))
+    {
+        // UE_LOG: 필수 객체 없음
+        return;
+    }
+
+    // 이미 초기화되었다면 기존 것 해제
+    if (PImpl->RigidActor)
+    {
+        TermBody();
+        // PImpl은 유지하고 내부 RigidActor만 새로 만듦
+        PImpl->RigidActor = nullptr; // 명시적 초기화
+    }
+
+    OwnerComponent = InOwnerComponent;
+    PImpl->bIsSimulatingPhysics = bInSimulatePhysics;
+
+    const FVector Location = InTransform.GetLocation();
+    const FQuat Rotation = InTransform.GetRotation();
+
+    const PxTransform PxPose(
+        PxVec3(Location.X, Location.Y, Location.Z),
+        PxQuat(
+            Rotation.X, Rotation.Y, Rotation.Z, Rotation.W
+        )
+    );
+
+    if (PImpl->bIsSimulatingPhysics)
+    {
+        PImpl->RigidActor = GPhysics->createRigidDynamic(PxPose);
+    }
+    else
+    {
+        PImpl->RigidActor = GPhysics->createRigidStatic(PxPose);
+    }
+
+    if (!PImpl->RigidActor)
+    {
+        // UE_LOG: RigidActor 생성 실패
+        return;
+    }
+
+    // userData에 FBodyInstance* this를 저장 (PhysX 콜백 등에서 다시 FBodyInstance를 얻기 위함)
+    PImpl->RigidActor->userData = this;
+
+    PImpl->CreateShapesFromAggGeom(InBodySetup, PImpl->RigidActor);
+
+    if (PImpl->bIsSimulatingPhysics && PImpl->RigidActor->is<PxRigidDynamic>())
+    {
+        // TODO: BodySetupRef 또는 OwnerComponent에서 질량/관성 관련 데이터 가져오기
+        constexpr float Mass = 10.0f; // TODO: 예시 질량
+        if (InBodySetup /* && BodySetupRef->Mass > 0 */)
+        {
+            /* Mass = BodySetupRef->Mass; */
+        }
+        PxRigidBodyExt::updateMassAndInertia(*static_cast<PxRigidDynamic*>(PImpl->RigidActor), Mass);
+    }
+
+    GScene->addActor(*(PImpl->RigidActor));
+}
+
+void FBodyInstance::TermBody()
+{
+    if (PImpl && PImpl->RigidActor)
+    {
+        if (GScene)
+        {
+            GScene->removeActor(*(PImpl->RigidActor));
+        }
+        PImpl->RigidActor->release();
+        PImpl->RigidActor = nullptr;
+    }
+    // OwnerComponent는 TermBody에서 null로 만들지 않음. InitBody에서 새로 설정.
+    // 또는 FBodyInstance 소멸 시 OwnerComponent = nullptr; 처리.
+}
+
+void FBodyInstance::SyncPhysXToComponent()
+{
+    if (PImpl && PImpl->RigidActor && OwnerComponent && PImpl->bIsSimulatingPhysics) // 물리 시뮬레이션 중일 때만 동기화
+    {
+        PxSceneReadLock ScopedReadLock{*GScene};
+
+        const PxTransform PxPose = PImpl->RigidActor->getGlobalPose();
+        const FVector NewLocation(PxPose.p.x, PxPose.p.y, PxPose.p.z);
+        const FQuat NewRotation(PxPose.q.x, PxPose.q.y, PxPose.q.z, PxPose.q.w);
+
+        OwnerComponent->SetWorldLocationAndRotation(NewLocation, NewRotation);
+    }
+}
+
+void FBodyInstance::SyncComponentToPhysX()
+{
+    if (PImpl && PImpl->RigidActor && OwnerComponent && PImpl->bIsSimulatingPhysics)
+    {
+        PxSceneWriteLock ScopedWriteLock{*GScene};
+
+        const FTransform NewTransform = OwnerComponent->GetComponentTransform();
+        const FVector NewLocation = NewTransform.GetLocation();
+        const FQuat NewRotation = NewTransform.GetRotation();
+
+        const PxTransform PxNewPose{
+            PxVec3(NewLocation.X, NewLocation.Y, NewLocation.Z),
+            PxQuat(NewRotation.X, NewRotation.Y, NewRotation.Z, NewRotation.W)
+        };
+
+        PImpl->RigidActor->setGlobalPose(PxNewPose);
+    }
+}
+
+bool FBodyInstance::IsValidBodyInstance() const
+{
+    return PImpl && PImpl->RigidActor;
+}
+
+void FBodyInstance::AddForce(const FVector& Force, bool bAccelChange)
+{
+    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    {
+        PxRigidBody* RigidBody = static_cast<PxRigidBody*>(PImpl->RigidActor);
+        const PxVec3 PxForce(Force.X, Force.Y, Force.Z);
+        const PxForceMode::Enum Mode = bAccelChange ? PxForceMode::eACCELERATION : PxForceMode::eFORCE;
+        RigidBody->addForce(PxForce, Mode);
+    }
+}
+
+void FBodyInstance::SetLinearVelocity(const FVector& NewVel, bool bAddToCurrent)
+{
+    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    {
+        PxRigidBody* RigidBody = static_cast<PxRigidBody*>(PImpl->RigidActor);
+        PxVec3 PxNewVel(NewVel.X, NewVel.Y, NewVel.Z);
+        if (bAddToCurrent)
+        {
+            PxNewVel += RigidBody->getLinearVelocity();
+        }
+        RigidBody->setLinearVelocity(PxNewVel);
+    }
+}
+
+FVector FBodyInstance::GetLinearVelocity() const
+{
+    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    {
+        const PxVec3 PxVel = static_cast<PxRigidBody*>(PImpl->RigidActor)->getLinearVelocity();
+        return FVector{PxVel.x, PxVel.y, PxVel.z};
+    }
+    return FVector::ZeroVector;
+}
+
+void FBodyInstance::SetAngularVelocity(const FVector& NewAngVel, bool bAddToCurrent)
+{
+    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    {
+        PxRigidBody* RigidBody = static_cast<PxRigidBody*>(PImpl->RigidActor);
+        PxVec3 PxNewAngVel(NewAngVel.X, NewAngVel.Y, NewAngVel.Z); // 엔진 좌표계와 PhysX 좌표계가 다르면 변환 필요
+        if (bAddToCurrent)
+        {
+            PxNewAngVel += RigidBody->getAngularVelocity();
+        }
+        RigidBody->setAngularVelocity(PxNewAngVel);
+    }
+}
+
+FVector FBodyInstance::GetAngularVelocity() const
+{
+    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    {
+        const PxVec3 PxAngVel = static_cast<PxRigidBody*>(PImpl->RigidActor)->getAngularVelocity();
+        return FVector{PxAngVel.x, PxAngVel.y, PxAngVel.z}; // 좌표계 변환 필요할 수 있음
+    }
+    return FVector::ZeroVector;
+}
+
+FTransform FBodyInstance::GetWorldTransform() const
+{
+    if (PImpl && PImpl->RigidActor)
+    {
+        const PxTransform PxPose = PImpl->RigidActor->getGlobalPose();
+        return FTransform{
+            FQuat(PxPose.q.x, PxPose.q.y, PxPose.q.z, PxPose.q.w),
+            FVector(PxPose.p.x, PxPose.p.y, PxPose.p.z)
+        };
+    }
+    return FTransform::Identity;
+}
+
+void FBodyInstance::SetWorldTransform(const FTransform& NewTransform, bool bTeleportPhysics)
+{
+    if (PImpl && PImpl->RigidActor)
+    {
+        const PxTransform PxNewPose(
+            PxVec3(NewTransform.GetLocation().X, NewTransform.GetLocation().Y, NewTransform.GetLocation().Z),
+            PxQuat(NewTransform.GetRotation().X, NewTransform.GetRotation().Y, NewTransform.GetRotation().Z, NewTransform.GetRotation().W)
+        );
+
+        if (PImpl->RigidActor->is<PxRigidDynamic>())
+        {
+            // bTeleportPhysics 플래그는 PhysX에서 직접적으로 지원하는 것은 아니지만,
+            // Kinematic Actor의 경우 setKinematicTarget, Dynamic Actor의 경우 setGlobalPose 후 wakeUp 등을 의미할 수 있음.
+            // 간단히 setGlobalPose 사용. Kinematic인 경우 추가 처리가 필요할 수 있음.
+            PImpl->RigidActor->setGlobalPose(PxNewPose);
+            if (!bTeleportPhysics) // 순간이동이 아니면 깨움 (물리가 즉시 반응하도록)
+            {
+                static_cast<PxRigidDynamic*>(PImpl->RigidActor)->wakeUp();
+            }
+        }
+        else if (PImpl->RigidActor->is<PxRigidStatic>())
+        {
+            // Static Actor는 런타임에 Transform 변경 불가 (만약 필요하면 재생성해야 함)
+            // UE_LOG: Static Actor의 Transform은 변경할 수 없습니다.
+        }
+    }
+}
+
+void FBodyInstance::SetSimulatePhysics(bool bSimulate)
+{
+    if (PImpl && PImpl->bIsSimulatingPhysics != bSimulate)
+    {
+        PImpl->bIsSimulatingPhysics = bSimulate;
+        if (PImpl->RigidActor)
+        {
+            // TODO: 실제로는 Actor Type을 Dynamic <-> Static으로 변경하거나,
+            // Dynamic Actor의 플래그를 변경하는 복잡한 과정이 필요할 수 있습니다.
+            // (예: PxRigidBodyFlag::eKINEMATIC 설정/해제)
+            // 여기서는 단순 플래그만 변경하고, InitBody 시점에 실제 Actor Type이 결정된다고 가정합니다.
+            // 혹은, 해당 플래그에 따라 Actor를 재생성해야 할 수도 있습니다.
+            if (PImpl->RigidActor->is<PxRigidDynamic>())
+            {
+                // 물리 시뮬레이션을 끄면 Kinematic으로 만들거나 Gravity를 끌 수 있음
+                // 여기서는 간단히 Actor flag를 조절한다고 가정 (예시)
+                // static_cast<physx::PxRigidDynamic*>(PImpl->RigidActor)->setRigidBodyFlag(physx::PxRigidBodyFlag::eKINEMATIC, !bSimulate);
+            }
+            // UE_LOG: SetSimulatePhysics 호출됨, 현재 상태: %s", bSimulate ? "On" : "Off");
+        }
+    }
+}
+
+bool FBodyInstance::IsSimulatingPhysics() const
+{
+    return PImpl && PImpl->bIsSimulatingPhysics;
+}
+
+
+void FBodyInstance::SetUserData(void* InUserData)
+{
+    if (PImpl)
+    {
+        PImpl->UserData = InUserData;
+    }
+}
+
+void* FBodyInstance::GetUserData() const
+{
+    return PImpl ? PImpl->UserData : nullptr;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
@@ -254,10 +254,10 @@ void FBodyInstance::InitBody(
     if (PImpl->bIsSimulatingPhysics && PImpl->RigidActor->is<PxRigidDynamic>())
     {
         // TODO: BodySetupRef 또는 OwnerComponent에서 질량/관성 관련 데이터 가져오기
-        constexpr float Mass = 10.0f; // TODO: 예시 질량
-        if (InBodySetup /* && BodySetupRef->Mass > 0 */)
+        float Mass = 0.001f;
+        if (InBodySetup && InBodySetup->Mass > 0)
         {
-            /* Mass = BodySetupRef->Mass; */
+            Mass = InBodySetup->Mass; 
         }
         PxRigidBodyExt::updateMassAndInertia(*static_cast<PxRigidDynamic*>(PImpl->RigidActor), Mass);
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include "BodyInstanceCore.h"
 
+class UBodySetup;
 class UPrimitiveComponent;
 
 
@@ -9,14 +10,41 @@ struct FBodyInstance : FBodyInstanceCore
     DECLARE_STRUCT(FBodyInstance, FBodyInstanceCore)
 
 public:
-    FBodyInstance() = default;
-    virtual ~FBodyInstance() override = default;
+    FBodyInstance();
+    virtual ~FBodyInstance() override;
 
-    FBodyInstance(const FBodyInstance&) = default;
-    FBodyInstance& operator=(const FBodyInstance&) = default;
-    FBodyInstance(FBodyInstance&&) = default;
-    FBodyInstance& operator=(FBodyInstance&&) = default;
+    FBodyInstance(const FBodyInstance&) = delete;
+    FBodyInstance& operator=(const FBodyInstance&) = delete;
+    FBodyInstance(FBodyInstance&&) noexcept;
+    FBodyInstance& operator=(FBodyInstance&&) noexcept;
 
 public:
+    UPrimitiveComponent* GetOwnerComponent() const { return OwnerComponent; }
+
+    void InitBody(UPrimitiveComponent* InOwnerComponent, const UBodySetup* InBodySetup, const FTransform& InTransform, bool bInSimulatePhysics);
+    void TermBody();
+
+    void SyncPhysXToComponent();
+    void SyncComponentToPhysX();
+
+    bool IsValidBodyInstance() const;
+
+    void AddForce(const FVector& Force, bool bAccelChange);
+    void SetLinearVelocity(const FVector& NewVel, bool bAddToCurrent);
+    FVector GetLinearVelocity() const;
+    void SetAngularVelocity(const FVector& NewAngVel, bool bAddToCurrent);
+    FVector GetAngularVelocity() const;
+    FTransform GetWorldTransform() const;
+    void SetWorldTransform(const FTransform& NewTransform, bool bTeleportPhysics);
+    void SetSimulatePhysics(bool bSimulate);
+    bool IsSimulatingPhysics() const;
+
+    void SetUserData(void* InUserData);
+    void* GetUserData() const;
+
+private:
     TWeakObjectPtr<UPrimitiveComponent> OwnerComponent;
+
+    struct FBodyInstancePImpl;
+    std::unique_ptr<FBodyInstancePImpl> PImpl;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
@@ -18,7 +18,7 @@ public:
     )
 
     UPROPERTY(
-        EditAnywhere | LuaReadWrite, ({ .Category = "Physics", .ClampMin = 0.001f }),
+        EditAnywhere | LuaReadWrite, ({ .Category = "Physics", .ToolTip = "Mass of the body for physics simulation", .ClampMin = 0.001f }),
         float, Mass, = 10.f;
     )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
@@ -16,4 +16,9 @@ public:
         EditAnywhere, ({ .Category = "BodySetup", .DisplayName = "Primitives" }),
         FKAggregateGeom, AggGeom, ;
     )
+
+    UPROPERTY(
+        EditAnywhere | LuaReadWrite, ({ .Category = "Physics", .ClampMin = 0.001f }),
+        float, Mass, = 10.f;
+    )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BoxElem.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BoxElem.h
@@ -51,7 +51,7 @@ public:
 
     /** Extent of the box along the y-axis */
     UPROPERTY(
-        EditAnywhere, ({ .Category = "Box", .DisplayName = "X Extent", .ToolTip = "Extent of the box along the y-axis" }),
+        EditAnywhere, ({ .Category = "Box", .DisplayName = "X Extent", .ToolTip = "Extent of the box along the x-axis" }),
         float, X, ;
     )
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BoxElem.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BoxElem.h
@@ -8,11 +8,62 @@ struct FKBoxElem : public FKShapeElem
     DECLARE_STRUCT(FKBoxElem, FKShapeElem)
 
 public:
-    FKBoxElem() = default;
+    FKBoxElem()
+        : Center(FVector::ZeroVector)
+        , Rotation(FRotator::ZeroRotator)
+        , X(1.0f), Y(1.0f), Z(1.0f)
+    {
+    }
+
+    FKBoxElem(float InScale)
+        : Center(FVector::ZeroVector)
+        , Rotation(FRotator::ZeroRotator)
+        , X(InScale), Y(InScale), Z(InScale)
+    {
+    }
+
+    FKBoxElem(float InX, float InY, float InZ)
+        : Center(FVector::ZeroVector)
+        , Rotation(FRotator::ZeroRotator)
+        , X(InX), Y(InY), Z(InZ)
+    {
+    }
+
     virtual ~FKBoxElem() override = default;
 
     FKBoxElem(const FKBoxElem&) = default;
     FKBoxElem& operator=(const FKBoxElem&) = default;
     FKBoxElem(FKBoxElem&&) = default;
     FKBoxElem& operator=(FKBoxElem&&) = default;
+
+public:
+    /** Position of the box's origin */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Box", .ToolTip = "Position of the box's origin" }),
+        FVector, Center, ;
+    )
+
+    /** Rotation of the box */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Box", .ToolTip = "Rotation of the box", .ClampMin = -360.0f, .ClampMax = 360.0f }),
+        FRotator, Rotation, ;
+    )
+
+    /** Extent of the box along the y-axis */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Box", .DisplayName = "X Extent", .ToolTip = "Extent of the box along the y-axis" }),
+        float, X, ;
+    )
+
+    /** Extent of the box along the y-axis */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Box", .DisplayName = "Y Extent", .ToolTip = "Extent of the box along the y-axis" }),
+        float, Y, ;
+    )
+
+    /** Extent of the box along the z-axis */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Box", .DisplayName = "Z Extent", .ToolTip = "Extent of the box along the z-axis" }),
+        float, Z, ;
+    )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
@@ -40,5 +40,6 @@ public:
     // TODO: Implements This
     void TermConstraint()
     {
+        UE_LOG(ELogLevel::Warning, TEXT("TermConstraint is not implemented yet."));
     }
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
@@ -16,6 +16,7 @@ public:
     FConstraintInstanceBase& operator=(FConstraintInstanceBase&&) = default;
 };
 
+
 struct FConstraintInstance : public FConstraintInstanceBase
 {
     DECLARE_STRUCT(FConstraintInstance, FConstraintInstanceBase)
@@ -34,4 +35,10 @@ public:
         VisibleAnywhere, { .Category = "Constraint" },
         FName, JointName, ;
     )
+
+public:
+    // TODO: Implements This
+    void TermConstraint()
+    {
+    }
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConvexElem.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConvexElem.h
@@ -15,4 +15,13 @@ public:
     FKConvexElem& operator=(const FKConvexElem&) = default;
     FKConvexElem(FKConvexElem&&) = default;
     FKConvexElem& operator=(FKConvexElem&&) = default;
+
+public:
+    UPROPERTY(
+        TArray<FVector>, VertexData
+    )
+
+    UPROPERTY(
+        TArray<int32>, IndexData
+    )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
@@ -48,6 +48,9 @@ void FPhysX::Initialize()
     GDispatcher = PxDefaultCpuDispatcherCreate(8); // 연산에 사용할 스레드 개수
     SceneDesc.cpuDispatcher = GDispatcher;
     SceneDesc.filterShader = PxDefaultSimulationFilterShader;
+    SceneDesc.flags |= PxSceneFlag::eENABLE_ACTIVE_ACTORS;
+    SceneDesc.flags |= PxSceneFlag::eENABLE_CCD;
+    SceneDesc.flags |= PxSceneFlag::eENABLE_PCM;
     GScene = GPhysics->createScene(SceneDesc);
 
 #ifdef _DEBUG

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+
 struct FPhysX
 {
     static void Initialize();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysicsAsset.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysicsAsset.h
@@ -15,6 +15,7 @@ public:
 
 public:
     UPROPERTY(
+        EditAnywhere | EditInline,
         TArray<UBodySetup*>, BodySetup, ;
     )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/SphereElem.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/SphereElem.h
@@ -8,11 +8,34 @@ struct FKSphereElem : public FKShapeElem
     DECLARE_STRUCT(FKSphereElem, FKShapeElem)
 
 public:
-    FKSphereElem() = default;
+    FKSphereElem()
+        : Center(FVector::ZeroVector)
+        , Radius(0.0f)
+    {
+    }
+
+    FKSphereElem(float InRadius)
+        : Center(FVector::ZeroVector)
+        , Radius(InRadius)
+    {
+    }
     virtual ~FKSphereElem() override = default;
 
     FKSphereElem(const FKSphereElem&) = default;
     FKSphereElem& operator=(const FKSphereElem&) = default;
     FKSphereElem(FKSphereElem&&) = default;
     FKSphereElem& operator=(FKSphereElem&&) = default;
+
+public:
+    /** Position of the sphere's origin */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Sphere", .ToolTip = "Position of the sphere's origin" }),
+        FVector, Center, ;
+    )
+
+    /** Radius of the sphere */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Sphere", .ToolTip = "Radius of the sphere" }),
+        float, Radius, ;
+    )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/SphylElem.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/SphylElem.h
@@ -15,4 +15,29 @@ public:
     FKSphylElem& operator=(const FKSphylElem&) = default;
     FKSphylElem(FKSphylElem&&) = default;
     FKSphylElem& operator=(FKSphylElem&&) = default;
+
+public:
+    /** Position of the capsule's origin */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Capsule", .ToolTip = "Position of the capsule's origin" }),
+        FVector, Center, ;
+    )
+
+    /** Rotation of the capsule */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Capsule", .ToolTip = "Rotation of the capsule", .ClampMin = -360.0f, .ClampMax = 360.0f }),
+        FRotator, Rotation, ;
+    )
+
+    /** Radius of the capsule */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Capsule", .ToolTip = "Radius of the capsule" }),
+        float, Radius, ;
+    )
+
+    /** This is of line-segment ie. add Radius to both ends to find total length. */
+    UPROPERTY(
+        EditAnywhere, ({ .Category = "Capsule", .ToolTip = "This is of line-segment ie. add Radius to both ends to find total length." }),
+        float, Length, ;
+    )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
@@ -169,9 +169,22 @@ void FEngineLoop::Tick()
 
         const float DeltaTime = static_cast<float>(ElapsedTime / 1000.f);
 
+        // TODO: 반드시 리펙토링 해야 함
+        for (UPrimitiveComponent* Primitive : TObjectRange<UPrimitiveComponent>())
+        {
+            Primitive->BodyInstance.SyncComponentToPhysX();
+        }
+
         GEngine->Tick(DeltaTime);
         LevelEditor->Tick(DeltaTime);
         FPhysX::Tick(DeltaTime);
+
+        // TODO: 반드시 리펙토링 해야 함
+        for (UPrimitiveComponent* Primitive : TObjectRange<UPrimitiveComponent>())
+        {
+            Primitive->PhysicsTick();
+        }
+
         Render();
         UIManager->BeginFrame();
         UnrealEditor->Render();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
@@ -172,7 +172,10 @@ void FEngineLoop::Tick()
         // TODO: 반드시 리펙토링 해야 함
         for (UPrimitiveComponent* Primitive : TObjectRange<UPrimitiveComponent>())
         {
-            Primitive->BodyInstance.SyncComponentToPhysX();
+            if (Primitive->GetWorld() == GEngine->ActiveWorld)
+            {
+                Primitive->BodyInstance.SyncComponentToPhysX();
+            }
         }
 
         GEngine->Tick(DeltaTime);
@@ -182,7 +185,10 @@ void FEngineLoop::Tick()
         // TODO: 반드시 리펙토링 해야 함
         for (UPrimitiveComponent* Primitive : TObjectRange<UPrimitiveComponent>())
         {
-            Primitive->PhysicsTick();
+            if (Primitive->GetWorld() == GEngine->ActiveWorld)
+            {
+                Primitive->PhysicsTick();
+            }
         }
 
         Render();

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -300,6 +300,7 @@
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocity.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityBase.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityOverLife.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstance.cpp"/>
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetup.cpp"/>
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetupCore.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysicsAsset.cpp"/>
@@ -587,7 +588,7 @@
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityBase.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityOverLife.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\AggregateGeom.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstance.h"/>
+      <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstance.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstanceCore.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetup.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetupCore.h" />


### PR DESCRIPTION
## 주요 변경사항
> 아래 내용은 AI가 요약하였습니다.
- `BodySetup`에 질량 속성을 추가하고, 물리 시뮬레이션에 질량을 통합했습니다.
- 현재 활성화된 월드에 대해서만 동기화 및 Tick 호출이 이루어지도록 수정했습니다.
- `EditFixedSize` 플래그 처리 방식을 개선하고, `ImGui` 배열 수정 로직을 향상시켰습니다.
- `GetComponentToWorld`를 `GetComponentTransform`으로 교체하여 코드를 리팩터링했습니다.
- Tick 로직에서 누락된 `UPrimitiveComponent` 처리를 수정하고, 임시 해결책을 추가했습니다.
- `TermConstraint` 함수 선언을 추가했습니다.
- 물리 상태 생성/파괴 및 `StaticMesh` 관련 기능을 추가했습니다.
- `UStaticMesh` 생성자와 `BodySetup`의 초기화 로직을 조정했습니다.
- 물리 엔진에 시뮬레이션 및 변환 관련 기능을 추가했습니다.
- `EditFixedSize`를 제거하고, 이에 따라 `UPROPERTY` 설정을 정리했습니다.
- 물리 시뮬레이션 로직을 포함한 `BodyInstance` 클래스를 구현했습니다.
- `Transform` 클래스에 `GetLocation` 함수를 추가했습니다.
- 물리 엔진 요소 클래스에 `UPROPERTY` 선언과 초기화를 위한 생성자를 추가했습니다.
- `PhysX SceneDesc` 플래그(`eENABLE_ACTIVE_ACTORS`, `eENABLE_CCD`, `eENABLE_PCM`)를 설정했습니다.