### PR TITLE
충돌 필터링 및 이벤트 처리 개선 사항 추가

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -1108,11 +1108,9 @@ struct TEnumProperty : public FProperty
 
     virtual void DisplayInImGui(UObject* Object) const override
     {
-        ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
         {
             FProperty::DisplayInImGui(Object);
         }
-        ImGui::EndDisabled();
     }
 
 protected:
@@ -1120,41 +1118,108 @@ protected:
     {
         FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
+        if (HasAnyFlags(Flags, BitMask))
+        {
+            DisplayBitMask(PropertyLabel, DataPtr, OwnerObject);
+        }
+        else
+        {
+            DisplayComboBox(PropertyLabel, DataPtr, OwnerObject);
+        }
+    }
+
+private:
+    void DisplayBitMask(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+    {
+        using namespace magic_enum::bitwise_operators;
+
         EnumType* Data = static_cast<EnumType*>(DataPtr);
         constexpr auto EnumEntries = magic_enum::enum_entries<EnumType>();
 
-        const std::string_view CurrentNameView = magic_enum::enum_name(*Data);
-        const std::string CurrentName = std::string(CurrentNameView);
+        if (ImGui::TreeNode(PropertyLabel))
+        {
+            // 툴팁 표시
+            if (Metadata.ToolTip.IsSet())
+            {
+                ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+            }
 
-        ImGui::Text("%s", PropertyLabel);
-        // 툴팁 표시
-        if (Metadata.ToolTip.IsSet())
-        {
-            ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
-        }
-        ImGui::SameLine();
-        if (ImGui::BeginCombo(std::format("##{}", PropertyLabel).c_str(), CurrentName.c_str()))
-        {
             for (const auto& [Enum, NameView] : EnumEntries)
             {
                 const std::string EnumName = std::string(NameView);
-                const bool bIsSelected = (*Data == Enum);
-                if (ImGui::Selectable(EnumName.c_str(), bIsSelected))
+                const auto EnumValue = static_cast<std::underlying_type_t<EnumType>>(Enum);
+
+                // enum 값 자체가 이미 비트 플래그인 경우
+                bool IsChecked = (*Data & Enum) == Enum;
+
+                ImGui::PushID(static_cast<int>(EnumValue));
+                ImGui::Text("%s", EnumName.c_str());
+                ImGui::SameLine();
+
+                if (ImGui::Checkbox(std::format("##{}", EnumName).c_str(), &IsChecked))
                 {
-                    *Data = Enum;
+                    if (IsChecked)
+                    {
+                        *Data = static_cast<EnumType>(*Data | Enum);
+                    }
+                    else
+                    {
+                        *Data = static_cast<EnumType>(*Data & ~Enum);
+                    }
+
                     if (IsValid(OwnerObject))
                     {
                         FPropertyChangedEvent Event{const_cast<TEnumProperty*>(this), OwnerObject, EPropertyChangeType::ValueSet};
                         OwnerObject->PostEditChangeProperty(Event);
                     }
                 }
-                if (bIsSelected)
-                {
-                    ImGui::SetItemDefaultFocus();
-                }
+                ImGui::PopID();
             }
-            ImGui::EndCombo();
+            ImGui::TreePop();
         }
+    }
+
+    void DisplayComboBox(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+    {
+        EnumType* Data = static_cast<EnumType*>(DataPtr);
+        constexpr auto EnumEntries = magic_enum::enum_entries<EnumType>();
+
+        const std::string_view CurrentNameView = magic_enum::enum_name(*Data);
+        const std::string CurrentName = std::string(CurrentNameView);
+
+        ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
+        {
+            ImGui::Text("%s", PropertyLabel);
+            // 툴팁 표시
+            if (Metadata.ToolTip.IsSet())
+            {
+                ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+            }
+            ImGui::SameLine();
+            if (ImGui::BeginCombo(std::format("##{}", PropertyLabel).c_str(), CurrentName.c_str()))
+            {
+                for (const auto& [Enum, NameView] : EnumEntries)
+                {
+                    const std::string EnumName = std::string(NameView);
+                    const bool bIsSelected = (*Data == Enum);
+                    if (ImGui::Selectable(EnumName.c_str(), bIsSelected))
+                    {
+                        *Data = Enum;
+                        if (IsValid(OwnerObject))
+                        {
+                            FPropertyChangedEvent Event{const_cast<TEnumProperty*>(this), OwnerObject, EPropertyChangeType::ValueSet};
+                            OwnerObject->PostEditChangeProperty(Event);
+                        }
+                    }
+                    if (bIsSelected)
+                    {
+                        ImGui::SetItemDefaultFocus();
+                    }
+                }
+                ImGui::EndCombo();
+            }
+        }
+        ImGui::EndDisabled();
     }
 };
 
@@ -1271,6 +1336,21 @@ struct FUnresolvedPtrProperty : public FProperty
 
 namespace PropertyFactory::Private
 {
+template <typename E>
+constexpr bool IsFlagsRegistered()
+{
+    if constexpr (
+        requires { magic_enum::customize::enum_range<E>::is_flags; }
+    )
+    {
+        if constexpr (std::same_as<decltype(magic_enum::customize::enum_range<E>::is_flags), const bool>)
+        {
+            return magic_enum::customize::enum_range<E>::is_flags;
+        }
+    }
+    return false;
+}
+
 template <typename T, EPropertyFlags InFlags>
 FProperty* CreatePropertyForContainerType();
 
@@ -1286,28 +1366,41 @@ FProperty* MakeProperty(
     constexpr EPropertyType TypeEnum = GetPropertyType<T>();
 
     // Flags 검사
-    if constexpr (HasAllFlags<InFlags>(EPropertyFlags::EditAnywhere | EPropertyFlags::VisibleAnywhere))
-    {
-        // EditAnywhere와 VisibleAnywhere는 서로 같이 사용할 수 없음!!
-        static_assert(TAlwaysFalse<T>, "EditAnywhere and VisibleAnywhere cannot be set at the same time.");
-    }
-    else if constexpr (HasAllFlags<InFlags>(EPropertyFlags::LuaReadOnly | EPropertyFlags::LuaReadWrite))
-    {
-        // LuaReadOnly와 LuaReadWrite는 서로 같이 사용할 수 없음!!
-        static_assert(TAlwaysFalse<T>, "LuaReadOnly and LuaReadWrite cannot be set at the same time.");
-    }
-    else if constexpr (
-        !(
-            TypeEnum == EPropertyType::Object
-            || TypeEnum == EPropertyType::UnresolvedPointer
-            || TypeEnum == EPropertyType::Array
-        )
-        && HasAnyFlags<InFlags>(EPropertyFlags::EditInline)
-    )
-    {
-        // UObject가 아닌 타입에 대해서는 EditInline을 사용할 수 없음!!
-        static_assert(TAlwaysFalse<T>, "EditInline cannot be set for non-UObject types.");
-    }
+    // EditAnywhere와 VisibleAnywhere는 서로 같이 사용할 수 없음!!
+    static_assert(
+        !HasAllFlags<InFlags>(EPropertyFlags::EditAnywhere | EPropertyFlags::VisibleAnywhere),
+        "EditAnywhere and VisibleAnywhere cannot be set at the same time."
+    );
+
+    // LuaReadOnly와 LuaReadWrite는 서로 같이 사용할 수 없음!!
+    static_assert(
+        !HasAllFlags<InFlags>(EPropertyFlags::LuaReadOnly | EPropertyFlags::LuaReadWrite),
+        "LuaReadOnly and LuaReadWrite cannot be set at the same time."
+    );
+
+    // UObject가 아닌 타입에 대해서는 EditInline을 사용할 수 없음!!
+    static_assert(
+        TypeEnum == EPropertyType::Object
+        || TypeEnum == EPropertyType::UnresolvedPointer
+        || TypeEnum == EPropertyType::Array
+        || !HasAnyFlags<InFlags>(EPropertyFlags::EditInline),
+        "EditInline cannot be set for non-UObject types."
+    );
+
+    // Enum이 아닌 타입에 대해서는 BitMask를 사용할 수 없음!!
+    static_assert(
+        TypeEnum == EPropertyType::Enum
+        || !HasAnyFlags<InFlags>(EPropertyFlags::BitMask),
+        "BitMask cannot be set for non-Enum types."
+    );
+
+    // Enum에 BitMask를 사용하지만 magic_enum에 bit_flags를 등록하지 않은 경우
+    static_assert(
+        TypeEnum != EPropertyType::Enum
+        || IsFlagsRegistered<T>()
+        || !HasAnyFlags<InFlags>(EPropertyFlags::BitMask),
+        "magic_enum bit_flags must be registered for Enum type."
+    );
 
     if constexpr      (TypeEnum == EPropertyType::Int8)        { return new FInt8Property        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
     else if constexpr (TypeEnum == EPropertyType::Int16)       { return new FInt16Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
@@ -159,16 +159,17 @@ consteval EPropertyType GetPropertyType()
 
 enum EPropertyFlags : uint32  // NOLINT(performance-enum-size)
 {
-    PropertyNone       = 0,       // 플래그 없음
-    VisibleAnywhere    = 1 << 0,  // ImGui에서 읽기 전용으로 표시
-    EditAnywhere       = 1 << 1,  // ImGui에서 읽기/쓰기 가능
-    EditInline         = 1 << 2,  // ImGui에서 Edit과 동시에 Inline으로 Object의 Property까지 표시
-    EditFixedSize      = 1 << 3,  // ImGui에서 동적 배열의 길이를 바꾸지 못하도록 변경 (Add/Delete 불가)
-    LuaReadOnly        = 1 << 4,  // Lua에 읽기 전용으로 바인딩
-    LuaReadWrite       = 1 << 5,  // Lua에 읽기/쓰기로 바인딩
-    BitField           = 1 << 6,  // BitField인 경우
-    Transient          = 1 << 7,  // 휘발성 변수인 경우 (이 값은 저장이 안됨)
-    DuplicateTransient = 1 << 8,  // Duplicate할 때 기본값으로 복제
+    PropertyNone       = 0,      // 플래그 없음
+    VisibleAnywhere    = 1 << 0, // ImGui에서 읽기 전용으로 표시
+    EditAnywhere       = 1 << 1, // ImGui에서 읽기/쓰기 가능
+    EditInline         = 1 << 2, // ImGui에서 Edit과 동시에 Inline으로 Object의 Property까지 표시
+    EditFixedSize      = 1 << 3, // ImGui에서 동적 배열의 길이를 바꾸지 못하도록 변경 (Add/Delete 불가)
+    LuaReadOnly        = 1 << 4, // Lua에 읽기 전용으로 바인딩
+    LuaReadWrite       = 1 << 5, // Lua에 읽기/쓰기로 바인딩
+    BitField           = 1 << 6, // BitField인 경우
+    BitMask            = 1 << 7, // BitMask인 경우
+    Transient          = 1 << 8, // 휘발성 변수인 경우 (이 값은 저장이 안됨)
+    DuplicateTransient = 1 << 9, // Duplicate할 때 기본값으로 복제
     // ... 필요한 다른 플래그들 (예: SaveGame, Replicated 등)
 };
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.h
@@ -34,9 +34,19 @@ public:
 
     FBoundingBox AABB;
 
+    bool GetGenerateHitEvents() const { return bGenerateHitEvents; }
     bool GetGenerateOverlapEvents() const { return bGenerateOverlapEvents; }
-    
-    bool bGenerateOverlapEvents = true;
+
+    UPROPERTY(
+        EditAnywhere,
+        bool, bGenerateOverlapEvents, = true;
+    )
+
+    UPROPERTY(
+        EditAnywhere,
+        bool, bGenerateHitEvents, = true;
+    )
+
     bool bBlockComponent = true;
 
     FComponentHitSignature OnComponentHit;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/EngineTypes.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/EngineTypes.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Core/HAL/PlatformType.h"
+#include "magic_enum/magic_enum.hpp"
 
 namespace EEndPlayReason
 {
@@ -14,13 +15,21 @@ namespace EEndPlayReason
     };
 }
 
-enum class ECollisionChannel : uint8
+enum class ECollisionChannel : uint32
 {
-    WorldStatic,
-    WorldDynamic,
-    Pawn,
-    Visibility,
-    Camera,
-    PhysicsBody,
-    Vehicle,
+    WorldStatic  = 1 << 0,
+    WorldDynamic = 1 << 1,
+    Pawn         = 1 << 2,
+    Visibility   = 1 << 3,
+    Camera       = 1 << 4,
+    PhysicsBody  = 1 << 5,
+    Vehicle      = 1 << 6,
+    All          = 0xFFFFFFFF
+};
+
+// magic_enum에서 ECollisionChannel를 사용하기 위함
+template <>
+struct magic_enum::customize::enum_range<ECollisionChannel>
+{
+    static constexpr bool is_flags = true;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
@@ -24,12 +24,15 @@ void FBodyInstance::CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRi
         return;
     }
 
+    PxFilterData ShapeFilterData = BodySetupRef->CreateFilterData();
     const FKAggregateGeom& AggGeom = BodySetupRef->AggGeom;
 
     for (const FKSphereElem& SphereElem : AggGeom.SphereElems)
     {
         if (PxShape* Shape = CreateShapeFromSphere(SphereElem, *FPhysX::GMaterial))
         {
+            Shape->setSimulationFilterData(ShapeFilterData);
+            Shape->setQueryFilterData(ShapeFilterData);
             OutActor->attachShape(*Shape);
             Shape->release();
         }
@@ -39,6 +42,8 @@ void FBodyInstance::CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRi
     {
         if (PxShape* Shape = CreateShapeFromBox(BoxElem, *FPhysX::GMaterial))
         {
+            Shape->setSimulationFilterData(ShapeFilterData);
+            Shape->setQueryFilterData(ShapeFilterData);
             OutActor->attachShape(*Shape);
             Shape->release();
         }
@@ -48,6 +53,8 @@ void FBodyInstance::CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRi
     {
         if (PxShape* Shape = CreateShapeFromSphyl(SphylElem, *FPhysX::GMaterial))
         {
+            Shape->setSimulationFilterData(ShapeFilterData);
+            Shape->setQueryFilterData(ShapeFilterData);
             OutActor->attachShape(*Shape);
             Shape->release();
         }
@@ -57,6 +64,8 @@ void FBodyInstance::CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRi
     {
         if (PxShape* Shape = CreateShapeFromConvex(ConvexElem, *FPhysX::GMaterial))
         {
+            Shape->setSimulationFilterData(ShapeFilterData);
+            Shape->setQueryFilterData(ShapeFilterData);
             OutActor->attachShape(*Shape);
             Shape->release();
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.cpp
@@ -1,1 +1,23 @@
 ﻿#include "BodySetup.h"
+
+
+physx::PxFilterData UBodySetup::CreateFilterData() const
+{
+    physx::PxFilterData NewFilterData;
+
+    // word0: 이 객체의 타입 (하나의 비트만 설정하는 것이 일반적)
+    NewFilterData.word0 = static_cast<physx::PxU32>(ObjectType);
+
+    // word1: 이 객체가 블로킹 충돌할 대상 마스크
+    NewFilterData.word1 = static_cast<physx::PxU32>(CollisionResponses.BlockMask);
+
+    // word2: 이 객체가 오버랩/터치 이벤트를 발생시킬 대상 마스크 (또는 이벤트 발생 여부 플래그)
+    // 여기서는 간단히 터치(onContact) 이벤트를 위한 마스크를 word2에 저장한다고 가정.
+    // 또는 word2의 특정 비트를 사용하여 "히트 이벤트 생성" 플래그를 저장할 수도 있습니다.
+    NewFilterData.word2 = static_cast<physx::PxU32>(CollisionResponses.HitMask);
+
+    // word3: 추가 데이터 (여기서는 사용 안 함)
+    NewFilterData.word3 = 0;
+
+    return NewFilterData;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
@@ -1,7 +1,39 @@
 ﻿#pragma once
+#include <PxFiltering.h>
+
 #include "AggregateGeom.h"
 #include "BodySetupCore.h"
+#include "Engine/EngineTypes.h"
 
+
+struct FCollisionResponseContainer
+{
+    DECLARE_STRUCT(FCollisionResponseContainer)
+
+    // 각 채널에 대해 어떻게 반응할지 (Ignore, Overlap, Block)
+    UPROPERTY(
+        EditAnywhere | BitMask,
+        ECollisionChannel, BlockMask, ;
+    )
+
+    UPROPERTY(
+        EditAnywhere | BitMask,
+        ECollisionChannel, OverlapMask, ; // 트리거/오버랩 이벤트용
+    )
+
+    UPROPERTY(
+        EditAnywhere | BitMask,
+        ECollisionChannel, HitMask, ; // onContact 이벤트용
+    )
+
+    // 기본적으로 모든 것과 블로킹
+    FCollisionResponseContainer()
+        : BlockMask(ECollisionChannel::All)
+        , OverlapMask(static_cast<ECollisionChannel>(0))
+        , HitMask(ECollisionChannel::All)
+    {
+    }
+};
 
 class UBodySetup : public UBodySetupCore
 {
@@ -21,4 +53,16 @@ public:
         EditAnywhere | LuaReadWrite, ({ .Category = "Physics", .ToolTip = "Mass of the body for physics simulation", .ClampMin = 0.001f }),
         float, Mass, = 10.f;
     )
+
+    UPROPERTY(
+        EditAnywhere, { .Category = "Collision" },
+        ECollisionChannel, ObjectType, = ECollisionChannel::WorldDynamic;
+    )
+
+    UPROPERTY(
+        EditAnywhere, { .Category = "Collision" },
+        FCollisionResponseContainer, CollisionResponses, ;
+    )
+
+    physx::PxFilterData CreateFilterData() const;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/FSimulationEventCallback.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/FSimulationEventCallback.cpp
@@ -1,26 +1,175 @@
 ﻿#include "FSimulationEventCallback.h"
 
+#include <PxRigidActor.h>
 
-void FSimulationEventCallback::onConstraintBreak(physx::PxConstraintInfo* constraints, physx::PxU32 count)
+#include "Components/PrimitiveComponent.h"
+#include "Engine/HitResult.h"
+#include "GameFramework/Actor.h"
+#include "Math/Vector.h"
+#include "PhysicsEngine/BodyInstance.h"
+
+
+void FSimulationEventCallback::onConstraintBreak(physx::PxConstraintInfo* Constraints, physx::PxU32 Count)
 {
 }
 
-void FSimulationEventCallback::onWake(physx::PxActor** actors, physx::PxU32 count)
+void FSimulationEventCallback::onWake(physx::PxActor** Actors, physx::PxU32 Count)
 {
 }
 
-void FSimulationEventCallback::onSleep(physx::PxActor** actors, physx::PxU32 count)
+void FSimulationEventCallback::onSleep(physx::PxActor** Actors, physx::PxU32 Count)
 {
 }
 
-void FSimulationEventCallback::onContact(const physx::PxContactPairHeader& pairHeader, const physx::PxContactPair* pairs, physx::PxU32 nbPairs)
+void FSimulationEventCallback::onContact(const physx::PxContactPairHeader& PairHeader, const physx::PxContactPair* Pairs, physx::PxU32 NbPairs)
+{
+    // 1. 유효성 검사 및 기본 정보 추출
+    if (PairHeader.flags & (physx::PxContactPairHeaderFlag::eREMOVED_ACTOR_0 | physx::PxContactPairHeaderFlag::eREMOVED_ACTOR_1))
+    {
+        return; // 제거된 액터에 대한 이벤트는 무시
+    }
+
+    physx::PxRigidActor* RigidActorA_PhysX = PairHeader.actors[0];
+    physx::PxRigidActor* RigidActorB_PhysX = PairHeader.actors[1];
+
+    FBodyInstance* BodyInstA = RigidActorA_PhysX ? static_cast<FBodyInstance*>(RigidActorA_PhysX->userData) : nullptr;
+    FBodyInstance* BodyInstB = RigidActorB_PhysX ? static_cast<FBodyInstance*>(RigidActorB_PhysX->userData) : nullptr;
+
+    if (!BodyInstA || !BodyInstB)
+    {
+        // UE_LOG(LogPhysics, Warning, TEXT("onContact: BodyInstance userData is null for one or both actors."));
+        return;
+    }
+
+    UPrimitiveComponent* CompA = BodyInstA->GetOwnerComponent();
+    UPrimitiveComponent* CompB = BodyInstB->GetOwnerComponent();
+
+    if (!CompA || !CompB)
+    {
+        // UE_LOG(LogPhysics, Warning, TEXT("onContact: OwnerComponent is null for one or both BodyInstances."));
+        return;
+    }
+
+    AActor* ActorA = CompA->GetOwner();
+    AActor* ActorB = CompB->GetOwner();
+
+    if (!ActorA || !ActorB)
+    {
+        // UE_LOG(LogPhysics, Warning, TEXT("onContact: Owner Actor is null for one or both Components."));
+        return; // 액터가 없는 컴포넌트의 충돌은 일반적이지 않으므로 로그 후 반환 고려
+    }
+
+    // 2. 이벤트 생성 조건 확인 (각 컴포넌트가 Hit 이벤트를 생성하도록 설정되었는지)
+    bool bShouldGenerateHitEventsA = CompA->GetGenerateHitEvents();
+    bool bShouldGenerateHitEventsB = CompB->GetGenerateHitEvents();
+
+    if (!bShouldGenerateHitEventsA && !bShouldGenerateHitEventsB)
+    {
+        // 양쪽 모두 히트 이벤트를 생성하지 않도록 설정되어 있으면 반환
+        return;
+    }
+
+    // 3. 각 ContactPair 처리
+    for (physx::PxU32 i = 0; i < NbPairs; ++i)
+    {
+        const physx::PxContactPair& ContactPair = Pairs[i];
+
+        if (ContactPair.flags & (physx::PxContactPairFlag::eREMOVED_SHAPE_0 | physx::PxContactPairFlag::eREMOVED_SHAPE_1))
+        {
+            continue; // 제거된 Shape에 대한 이벤트는 무시
+        }
+
+        // "터치 시작" 이벤트만 처리 (가장 일반적인 경우)
+        // 필요에 따라 eNOTIFY_TOUCH_PERSISTS (계속 접촉 중), eNOTIFY_TOUCH_LOST (접촉 종료) 등도 처리 가능
+        if (ContactPair.events & physx::PxPairFlag::eNOTIFY_TOUCH_FOUND)
+        {
+            // 3.1. FHitResult 구성
+            // 하나의 물리적 충돌에 대해, 각 액터/컴포넌트 관점에서 FHitResult를 생성합니다.
+            FHitResult HitResultForA; // ActorA가 ActorB와 충돌한 결과
+            FHitResult HitResultForB; // ActorB가 ActorA와 충돌한 결과
+
+            // 3.2. 상세 접촉점 정보 추출
+            TArray<physx::PxContactPairPoint> ContactPoints; // PxContactPoint -> PxContactPairPoint 로 수정!
+            if (ContactPair.contactCount > 0)
+            {
+                ContactPoints.SetNum(ContactPair.contactCount);
+                ContactPair.extractContacts(
+                    ContactPoints.GetData(),
+                    ContactPair.contactCount
+                );
+
+                const physx::PxContactPairPoint& FirstContactPoint = ContactPoints[0]; // 편의상 첫 번째 접촉점 사용
+
+                // --- HitResultForA (CompA가 CompB와 충돌) ---
+                HitResultForA.bBlockingHit = true;                     // 물리적 충돌은 블로킹으로 간주
+                HitResultForA.Time = 0.0f;                             // 즉시 발생한 충돌
+                HitResultForA.Distance = FirstContactPoint.separation; // 분리 거리 (음수면 관통)
+
+                HitResultForA.ImpactPoint = FVector(FirstContactPoint.position.x, FirstContactPoint.position.y, FirstContactPoint.position.z);
+                HitResultForA.ImpactNormal = FVector(
+                    FirstContactPoint.normal.x, FirstContactPoint.normal.y, FirstContactPoint.normal.z
+                );                                                  // CompA에 대한 법선
+                HitResultForA.Location = HitResultForA.ImpactPoint; // 충돌 위치
+                HitResultForA.Normal = HitResultForA.ImpactNormal;  // 충돌 법선
+
+                // HitResultForA.Actor = ActorB;    // 충돌한 상대 액터
+                HitResultForA.Component = CompB; // 충돌한 상대 컴포넌트
+                // HitResultForA.BoneName = GetBoneNameFromShape(ContactPair.shapes[1]); // 상대방 Shape에 연결된 본 이름 (구현 필요)
+                // HitResultForA.PhysMaterial = BodyInstB->GetPhysicalMaterial();        // 상대방 물리 머티리얼 (구현 필요)
+
+                // --- HitResultForB (CompB가 CompA와 충돌) ---
+                // 기본 정보는 HitResultForA와 유사하지만, 관점이 다름
+                HitResultForB.bBlockingHit = true;
+                HitResultForB.Time = 0.0f;
+                HitResultForB.Distance = FirstContactPoint.separation; // 동일한 분리 거리
+
+                HitResultForB.ImpactPoint = HitResultForA.ImpactPoint;    // 충돌 지점은 동일
+                HitResultForB.ImpactNormal = -HitResultForA.ImpactNormal; // 법선 방향은 반대
+                HitResultForB.Location = HitResultForB.ImpactPoint;
+                HitResultForB.Normal = HitResultForB.ImpactNormal;
+
+                // HitResultForB.Actor = ActorA;
+                HitResultForB.Component = CompA;
+                // HitResultForB.BoneName = GetBoneNameFromShape(ContactPair.shapes[0]); // 자신의 Shape에 연결된 본 이름
+                // HitResultForB.PhysMaterial = BodyInstA->GetPhysicalMaterial();
+
+                // 3.3. 델리게이트 호출
+                // 각 액터/컴포넌트가 이벤트를 받도록 설정되어 있을 때만 호출
+
+                // CompA에 대한 이벤트
+                if (bShouldGenerateHitEventsA)
+                {
+                    // 사용자 엔진의 FComponentHitSignature에 맞게 파라미터 전달
+                    // 예시: CompA->OnComponentHit.Broadcast(MyComp, OtherActor, OtherComp, Normal, HitResult);
+                    // 여기서는 CompA, ActorB (상대 액터), CompB (상대 컴포넌트), HitResultForA.Normal, HitResultForA 를 전달한다고 가정
+                    CompA->OnComponentHit.Broadcast(CompA, ActorB, CompB, HitResultForA.Normal, HitResultForA);
+                    if (ActorA) // ActorA가 null이 아닐 때만 (위에서 이미 체크했지만, 안전하게)
+                    {
+                        // 사용자 엔진의 FActorHitSignature에 맞게 파라미터 전달
+                        // 예시: ActorA->OnActorHit.Broadcast(SelfActor, OtherActor, NormalImpulse, Hit);
+                        // 여기서는 ActorA, ActorB, CompA (자신의 컴포넌트), HitResultForA.ImpactPoint, HitResultForA.Normal 을 전달한다고 가정
+                        ActorA->OnActorHit.Broadcast(ActorA, ActorB, HitResultForA.ImpactPoint, HitResultForA);
+                    }
+                }
+
+                // CompB에 대한 이벤트
+                if (bShouldGenerateHitEventsB)
+                {
+                    CompB->OnComponentHit.Broadcast(CompB, ActorA, CompA, HitResultForB.Normal, HitResultForB);
+                    if (ActorB)
+                    {
+                        ActorB->OnActorHit.Broadcast(ActorB, ActorA, HitResultForB.ImpactPoint, HitResultForB);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void FSimulationEventCallback::onTrigger(physx::PxTriggerPair* Pairs, physx::PxU32 Count)
 {
 }
 
-void FSimulationEventCallback::onTrigger(physx::PxTriggerPair* pairs, physx::PxU32 count)
-{
-}
-
-void FSimulationEventCallback::onAdvance(const physx::PxRigidBody* const* bodyBuffer, const physx::PxTransform* poseBuffer, const physx::PxU32 count)
+void FSimulationEventCallback::onAdvance(const physx::PxRigidBody* const* BodyBuffer, const physx::PxTransform* PoseBuffer, const physx::PxU32 Count)
 {
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/FSimulationEventCallback.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/FSimulationEventCallback.cpp
@@ -1,0 +1,26 @@
+﻿#include "FSimulationEventCallback.h"
+
+
+void FSimulationEventCallback::onConstraintBreak(physx::PxConstraintInfo* constraints, physx::PxU32 count)
+{
+}
+
+void FSimulationEventCallback::onWake(physx::PxActor** actors, physx::PxU32 count)
+{
+}
+
+void FSimulationEventCallback::onSleep(physx::PxActor** actors, physx::PxU32 count)
+{
+}
+
+void FSimulationEventCallback::onContact(const physx::PxContactPairHeader& pairHeader, const physx::PxContactPair* pairs, physx::PxU32 nbPairs)
+{
+}
+
+void FSimulationEventCallback::onTrigger(physx::PxTriggerPair* pairs, physx::PxU32 count)
+{
+}
+
+void FSimulationEventCallback::onAdvance(const physx::PxRigidBody* const* bodyBuffer, const physx::PxTransform* poseBuffer, const physx::PxU32 count)
+{
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/FSimulationEventCallback.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/FSimulationEventCallback.h
@@ -8,10 +8,10 @@ public:
     FSimulationEventCallback() = default;
 
 public:
-    virtual void onConstraintBreak(physx::PxConstraintInfo* constraints, physx::PxU32 count) override;
-    virtual void onWake(physx::PxActor** actors, physx::PxU32 count) override;
-    virtual void onSleep(physx::PxActor** actors, physx::PxU32 count) override;
-    virtual void onContact(const physx::PxContactPairHeader& pairHeader, const physx::PxContactPair* pairs, physx::PxU32 nbPairs) override;
-    virtual void onTrigger(physx::PxTriggerPair* pairs, physx::PxU32 count) override;
-    virtual void onAdvance(const physx::PxRigidBody* const* bodyBuffer, const physx::PxTransform* poseBuffer, const physx::PxU32 count) override;
+    virtual void onConstraintBreak(physx::PxConstraintInfo* Constraints, physx::PxU32 Count) override;
+    virtual void onWake(physx::PxActor** Actors, physx::PxU32 Count) override;
+    virtual void onSleep(physx::PxActor** Actors, physx::PxU32 Count) override;
+    virtual void onContact(const physx::PxContactPairHeader& PairHeader, const physx::PxContactPair* Pairs, physx::PxU32 NbPairs) override;
+    virtual void onTrigger(physx::PxTriggerPair* Pairs, physx::PxU32 Count) override;
+    virtual void onAdvance(const physx::PxRigidBody* const* BodyBuffer, const physx::PxTransform* PoseBuffer, const physx::PxU32 Count) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/FSimulationEventCallback.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/FSimulationEventCallback.h
@@ -1,0 +1,17 @@
+﻿#pragma once
+#include <PxSimulationEventCallback.h>
+
+
+struct FSimulationEventCallback : public physx::PxSimulationEventCallback
+{
+public:
+    FSimulationEventCallback() = default;
+
+public:
+    virtual void onConstraintBreak(physx::PxConstraintInfo* constraints, physx::PxU32 count) override;
+    virtual void onWake(physx::PxActor** actors, physx::PxU32 count) override;
+    virtual void onSleep(physx::PxActor** actors, physx::PxU32 count) override;
+    virtual void onContact(const physx::PxContactPairHeader& pairHeader, const physx::PxContactPair* pairs, physx::PxU32 nbPairs) override;
+    virtual void onTrigger(physx::PxTriggerPair* pairs, physx::PxU32 count) override;
+    virtual void onAdvance(const physx::PxRigidBody* const* bodyBuffer, const physx::PxTransform* poseBuffer, const physx::PxU32 count) override;
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
@@ -17,14 +17,14 @@ static PxFilterFlags ContactReportFilterShader(
 
     // 1. 블로킹 충돌 여부 결정
     //    (obj0의 타입이 obj1의 블로킹 마스크에 포함되고, obj1의 타입이 obj0의 블로킹 마스크에 포함되는지)
-    bool bBlock = (FilterData0.word0 & FilterData1.word1) && (FilterData1.word0 & FilterData0.word1);
+    bool bBlock = ((FilterData0.word0 & FilterData1.word1) != 0) && ((FilterData1.word0 & FilterData0.word1) != 0);
 
     if (bBlock)
     {
         PairFlags = PxPairFlag::eCONTACT_DEFAULT; // 물리적 반작용
 
         // 2. onContact 이벤트 발생 여부 결정 (word2를 터치 마스크로 사용한다고 가정)
-        bool bNotifyTouch = (FilterData0.word0 & FilterData1.word2) && (FilterData1.word0 & FilterData0.word2);
+        bool bNotifyTouch = ((FilterData0.word0 & FilterData1.word2) != 0) && ((FilterData1.word0 & FilterData0.word2) != 0);
         if (bNotifyTouch)
         {
             PairFlags |= PxPairFlag::eNOTIFY_TOUCH_FOUND;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
@@ -118,7 +118,7 @@ void FPhysX::Initialize()
     GMaterial = GPhysics->createMaterial(0.5f, 0.5f, 0.6f);
 
     // PhysX Cooking 라이브러리 초기화 (필요시)
-    // PxInitExtensions(*GPhysics, pvd);
+    PxInitExtensions(*GPhysics, Pvd);
 }
 
 void FPhysX::Tick(float DeltaTime)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
@@ -147,7 +147,14 @@ void FPhysX::Initialize()
     GMaterial = GPhysics->createMaterial(0.5f, 0.5f, 0.6f);
 
     // PhysX Cooking 라이브러리 초기화 (필요시)
-    PxInitExtensions(*GPhysics, Pvd);
+    PxInitExtensions(
+        *GPhysics,
+#ifdef _DEBUG
+        Pvd
+#else
+        nullptr
+#endif
+    );
 }
 
 void FPhysX::Tick(float DeltaTime)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
@@ -61,7 +61,7 @@ void FPhysX::Initialize()
 
 void FPhysX::Tick(float DeltaTime)
 {
-#if _DEBUG
+#ifdef _DEBUG
     if (!bPIEMode)
     {
         return;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 
 
+struct FSimulationEventCallback;
+
 namespace physx
 {
 class PxPvdTransport;
@@ -27,6 +29,8 @@ public:
     inline static physx::PxDefaultCpuDispatcher* GDispatcher = nullptr;
     inline static physx::PxScene* GScene = nullptr;
     inline static physx::PxMaterial* GMaterial = nullptr; // 기본적인 재질
+
+    inline static FSimulationEventCallback* GSimulationEventCallback = nullptr;
 
 #ifdef _DEBUG
     inline static physx::PxPvd* Pvd = nullptr;

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -304,6 +304,7 @@
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetup.cpp"/>
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetupCore.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysicsAsset.cpp"/>
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\FSimulationEventCallback.cpp"/>
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\PhysX.cpp"/>
     <ClCompile Include="Engine\Source\Runtime\Engine\ParticleEmitterInstance.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\ParticleHelper.cpp" />
@@ -596,6 +597,7 @@
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ConstraintInstance.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ConvexElem.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysicsAsset.h"/>
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\FSimulationEventCallback.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\PhysX.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ShapeElem.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\SphereElem.h"/>


### PR DESCRIPTION
## 주요 변경사항
> 아래 내용은 AI가 요약하였습니다.
- BitMask 지원 추가 및 Enum 타입 처리 개선
- `ECollisionChannel`을 비트 플래그 지원이 포함된 `uint32`로 리팩토링하고 `magic_enum` 지원 추가
- PhysX 충돌 필터 로직 정리 및 차단/이벤트 처리 개선
- 필터 데이터 설정 추가로 PhysX Shape 생성 문제 수정
- PhysX 필터 데이터 생성 로직 도입 및 충돌 응답 구조체 추가
- `PxInitExtensions` 실행 중 발생하는 크래시 문제 해결
- 히트 이벤트 생성 기능 추가 및 콜백을 이용한 물리 시뮬레이션 필터 구현
- `onContact` 함수 구현으로 충돌 이벤트 처리 로직 강화
- PhysX 시뮬레이션 이벤트 콜백을 위한 `FSimulationEventCallback` 클래스 생성
- `_DEBUG` 조건부 컴파일 매크로 수정