### PR TITLE
Feat/rag doll

### DIFF
--- a/EngineSIU/EngineSIU/ConstraintInstance.cpp
+++ b/EngineSIU/EngineSIU/ConstraintInstance.cpp
@@ -21,14 +21,14 @@ void FConstraintInstance::InitConstraint(
         return;
     }
 
-    Body1 = InBody1;
+    Body1 = InBody1; 
     Body2 = InBody2;
     JointName = Setup->JointName;
 
     PxRigidActor* PActor1 = Body1->RigidActor;
     PxRigidActor* PActor2 = Body2->RigidActor;
-    PxTransform PLocalFrame1 = Setup->LocalFrame1;
-    PxTransform PLocalFrame2 = Setup->LocalFrame2;
+    PxTransform PLocalFrame1 = Setup->LocalFrame1.getNormalized();
+    PxTransform PLocalFrame2 = Setup->LocalFrame2.getNormalized();
     PxD6Joint* D6Joint = PxD6JointCreate(*GPhysics,
         PActor2, PLocalFrame2,
         PActor1, PLocalFrame1
@@ -44,27 +44,20 @@ void FConstraintInstance::InitConstraint(
     D6Joint->setMotion(PxD6Axis::eY, PxD6Motion::eLOCKED);
     D6Joint->setMotion(PxD6Axis::eZ, PxD6Motion::eLOCKED);
 
-    D6Joint->setMotion(PxD6Axis::eTWIST, PxD6Motion::eLIMITED); // Twist (Y-Z 평면 회전)
-    D6Joint->setMotion(PxD6Axis::eSWING1, PxD6Motion::eLIMITED); // Swing1 (X-Z 평면 회전)
-    D6Joint->setMotion(PxD6Axis::eSWING2, PxD6Motion::eLIMITED); // Swing2 (X-Y 평면 회전)
+    D6Joint->setMotion(PxD6Axis::eTWIST, PxD6Motion::eLIMITED);
+    D6Joint->setMotion(PxD6Axis::eSWING1, PxD6Motion::eLIMITED);
+    D6Joint->setMotion(PxD6Axis::eSWING2, PxD6Motion::eLIMITED);
+
+    D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, false);
 
     float TwistLimitRad = FMath::DegreesToRadians(Setup->AngularLimits.TwistLimitAngle);
-    D6Joint->setTwistLimit(PxJointAngularLimitPair(-TwistLimitRad, TwistLimitRad));
+    D6Joint->setTwistLimit(PxJointAngularLimitPair(-TwistLimitRad, TwistLimitRad, PxSpring(0, 0)));;
 
     float Swing1LimitRad = FMath::DegreesToRadians(Setup->AngularLimits.Swing1LimitAngle);
     float Swing2LimitRad = FMath::DegreesToRadians(Setup->AngularLimits.Swing2LimitAngle);
-    D6Joint->setSwingLimit(PxJointLimitCone(Swing1LimitRad, Swing2LimitRad));
-
-    //if (Setup->bDisableCollisionBetweenConstrainedBodies)
-    //{
-    //    D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, false);
-    //}
-    //else
-    //{
-    //    D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, true);
-    //}
-    D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, false);
-    D6Joint->setProjectionLinearTolerance(0.05f);
+    D6Joint->setSwingLimit(PxJointLimitCone(Swing1LimitRad, Swing2LimitRad, PxSpring(0, 0)));
+    
+    D6Joint->setProjectionLinearTolerance(0.5f);
     D6Joint->setProjectionAngularTolerance(FMath::DegreesToRadians(1.0f));
     D6Joint->setConstraintFlag(PxConstraintFlag::ePROJECTION, true);
 

--- a/EngineSIU/EngineSIU/ConstraintInstance.cpp
+++ b/EngineSIU/EngineSIU/ConstraintInstance.cpp
@@ -30,8 +30,8 @@ void FConstraintInstance::InitConstraint(
     PxTransform PLocalFrame1 = Setup->LocalFrame1;
     PxTransform PLocalFrame2 = Setup->LocalFrame2;
     PxD6Joint* D6Joint = PxD6JointCreate(*GPhysics,
-        PActor1, PLocalFrame1,
-        PActor2, PLocalFrame2
+        PActor2, PLocalFrame2,
+        PActor1, PLocalFrame1
     );
 
     if (!D6Joint)
@@ -55,16 +55,18 @@ void FConstraintInstance::InitConstraint(
     float Swing2LimitRad = FMath::DegreesToRadians(Setup->AngularLimits.Swing2LimitAngle);
     D6Joint->setSwingLimit(PxJointLimitCone(Swing1LimitRad, Swing2LimitRad));
 
-    if (Setup->bDisableCollisionBetweenConstrainedBodies)
-    {
-        D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, false);
-    }
-    else
-    {
-        D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, true);
-    }
-
-    // TODO: 필요시 Drive, Breakable 등의 추가 설정
+    //if (Setup->bDisableCollisionBetweenConstrainedBodies)
+    //{
+    //    D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, false);
+    //}
+    //else
+    //{
+    //    D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, true);
+    //}
+    D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, false);
+    D6Joint->setProjectionLinearTolerance(0.05f);
+    D6Joint->setProjectionAngularTolerance(FMath::DegreesToRadians(1.0f));
+    D6Joint->setConstraintFlag(PxConstraintFlag::ePROJECTION, true);
 
     Joint = D6Joint;
     bInitialized = true;

--- a/EngineSIU/EngineSIU/ConstraintInstance.cpp
+++ b/EngineSIU/EngineSIU/ConstraintInstance.cpp
@@ -4,10 +4,9 @@
 #include "Math/MathUtility.h"     
 #include "PxPhysicsAPI.h"
 #include "ConstraintSetup.h"
+#include "PhysicsEngine/PhysX/PhysX.h"
 
 using namespace physx;
-
-extern PxPhysics* GPhysics;
 
 void FConstraintInstance::InitConstraint(
     const UConstraintSetup* Setup,
@@ -16,7 +15,7 @@ void FConstraintInstance::InitConstraint(
     USkeletalMeshComponent* OwnerComp,
     bool bInSimulatePhysics)
 {
-    if (bInitialized || !GPhysics || !InBody1 || !InBody2 || !InBody1->RigidActor || !InBody2->RigidActor)
+    if (bInitialized || !FPhysX::GPhysics || !InBody1 || !InBody2 || !InBody1->RigidActor || !InBody2->RigidActor)
     {
         return;
     }
@@ -43,7 +42,7 @@ void FConstraintInstance::InitConstraint(
 
     PxTransform PLocalFrame_Parent = parentActorWorldPose.getInverse() * childJointFrameInWorld;
 
-    PxD6Joint* D6Joint = PxD6JointCreate(*GPhysics,
+    PxD6Joint* D6Joint = PxD6JointCreate(*FPhysX::GPhysics,
         PActor2,            // actor0 = 자식 (PActor2)
         PLocalFrame_Child,  // localFrame0 = 수정된 자식 기준 프레임
         PActor1,            // actor1 = 부모 (PActor1)

--- a/EngineSIU/EngineSIU/ConstraintInstance.cpp
+++ b/EngineSIU/EngineSIU/ConstraintInstance.cpp
@@ -9,17 +9,6 @@ using namespace physx;
 
 extern PxPhysics* GPhysics;
 
-PxTransform FConstraintInstance::ToPxTransform(const FTransform& UnrealTransform)
-{
-    const FVector Position = UnrealTransform.GetLocation();
-    FQuat Quaternion = UnrealTransform.GetRotation();
-    Quaternion.Normalize(); 
-    return PxTransform(
-        PxVec3(Position.X, Position.Y, Position.Z),
-        PxQuat(Quaternion.X, Quaternion.Y, Quaternion.Z, Quaternion.W) 
-    );
-}
-
 void FConstraintInstance::InitConstraint(
     const UConstraintSetup* Setup,
     FBodyInstance* InBody1,
@@ -38,8 +27,8 @@ void FConstraintInstance::InitConstraint(
 
     PxRigidActor* PActor1 = Body1->RigidActor;
     PxRigidActor* PActor2 = Body2->RigidActor;
-    PxTransform PLocalFrame1 = ToPxTransform(Setup->LocalFrame1);
-    PxTransform PLocalFrame2 = ToPxTransform(Setup->LocalFrame2);
+    PxTransform PLocalFrame1 = Setup->LocalFrame1;
+    PxTransform PLocalFrame2 = Setup->LocalFrame2;
     PxD6Joint* D6Joint = PxD6JointCreate(*GPhysics,
         PActor1, PLocalFrame1,
         PActor2, PLocalFrame2

--- a/EngineSIU/EngineSIU/ConstraintInstance.cpp
+++ b/EngineSIU/EngineSIU/ConstraintInstance.cpp
@@ -1,0 +1,99 @@
+#include "PhysicsEngine/ConstraintInstance.h"
+#include "PhysicsEngine/BodyInstance.h"
+#include "Components/SkeletalMeshComponent.h" 
+#include "Math/MathUtility.h"     
+#include "PxPhysicsAPI.h"
+#include "ConstraintSetup.h"
+
+using namespace physx;
+
+extern PxPhysics* GPhysics;
+
+PxTransform UConstraintInstance::ToPxTransform(const FTransform& UnrealTransform)
+{
+    const FVector Position = UnrealTransform.GetLocation();
+    FQuat Quaternion = UnrealTransform.GetRotation();
+    Quaternion.Normalize(); 
+    return PxTransform(
+        PxVec3(Position.X, Position.Y, Position.Z),
+        PxQuat(Quaternion.X, Quaternion.Y, Quaternion.Z, Quaternion.W) 
+    );
+}
+
+void UConstraintInstance::InitConstraint(
+    const UConstraintSetup* Setup,
+    FBodyInstance* InBody1,
+    FBodyInstance* InBody2,
+    USkeletalMeshComponent* OwnerComp,
+    bool bInSimulatePhysics)
+{
+    if (bInitialized || !GPhysics || !InBody1 || !InBody2 || !InBody1->RigidActor || !InBody2->RigidActor)
+    {
+        return;
+    }
+    Body1 = InBody1;
+    Body2 = InBody2;
+    JointName = Setup->JointName;
+
+    PxRigidActor* PActor1 = Body1->RigidActor;
+    PxRigidActor* PActor2 = Body2->RigidActor;
+
+    PxTransform PLocalFrame1 = ToPxTransform(Setup->LocalFrame1);
+    PxTransform PLocalFrame2 = ToPxTransform(Setup->LocalFrame2);
+
+    PxD6Joint* D6Joint = PxD6JointCreate(*GPhysics,
+        PActor1, PLocalFrame1,
+        PActor2, PLocalFrame2
+    );
+
+    if (!D6Joint)
+    {
+        // 로그: 조인트 생성 실패
+        return;
+    }
+
+    D6Joint->setMotion(PxD6Axis::eX, PxD6Motion::eLOCKED);
+    D6Joint->setMotion(PxD6Axis::eY, PxD6Motion::eLOCKED);
+    D6Joint->setMotion(PxD6Axis::eZ, PxD6Motion::eLOCKED);
+
+    D6Joint->setMotion(PxD6Axis::eTWIST, PxD6Motion::eLIMITED); // Twist (Y-Z 평면 회전)
+    D6Joint->setMotion(PxD6Axis::eSWING1, PxD6Motion::eLIMITED); // Swing1 (X-Z 평면 회전)
+    D6Joint->setMotion(PxD6Axis::eSWING2, PxD6Motion::eLIMITED); // Swing2 (X-Y 평면 회전)
+
+    float TwistLimitRad = FMath::DegreesToRadians(Setup->AngularLimits.TwistLimitAngle);
+    D6Joint->setTwistLimit(PxJointAngularLimitPair(-TwistLimitRad, TwistLimitRad));
+
+    float Swing1LimitRad = FMath::DegreesToRadians(Setup->AngularLimits.Swing1LimitAngle);
+    float Swing2LimitRad = FMath::DegreesToRadians(Setup->AngularLimits.Swing2LimitAngle);
+    D6Joint->setSwingLimit(PxJointLimitCone(Swing1LimitRad, Swing2LimitRad));
+
+    if (Setup->bDisableCollisionBetweenConstrainedBodies)
+    {
+        D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, false);
+    }
+    else
+    {
+        D6Joint->setConstraintFlag(PxConstraintFlag::eCOLLISION_ENABLED, true);
+    }
+
+    // TODO: 필요시 Drive, Breakable 등의 추가 설정
+
+    Joint = D6Joint;
+    bInitialized = true;
+}
+
+void UConstraintInstance::TermConstraint()
+{
+    if (bInitialized && Joint)
+    {
+        if (Joint->getScene()) // 조인트가 씬에 연결되어 있는지 확인 (안전장치)
+        {
+            // PhysX 조인트 해제. PhysX Actor는 FBodyInstance에서 관리/해제.
+        }
+        Joint->release(); // PhysX 조인트 객체 자체를 해제
+        Joint = nullptr;
+    }
+    Body1 = nullptr;
+    Body2 = nullptr;
+    bInitialized = false;
+}

--- a/EngineSIU/EngineSIU/ConstraintInstance.cpp
+++ b/EngineSIU/EngineSIU/ConstraintInstance.cpp
@@ -9,7 +9,7 @@ using namespace physx;
 
 extern PxPhysics* GPhysics;
 
-PxTransform UConstraintInstance::ToPxTransform(const FTransform& UnrealTransform)
+PxTransform FConstraintInstance::ToPxTransform(const FTransform& UnrealTransform)
 {
     const FVector Position = UnrealTransform.GetLocation();
     FQuat Quaternion = UnrealTransform.GetRotation();
@@ -20,7 +20,7 @@ PxTransform UConstraintInstance::ToPxTransform(const FTransform& UnrealTransform
     );
 }
 
-void UConstraintInstance::InitConstraint(
+void FConstraintInstance::InitConstraint(
     const UConstraintSetup* Setup,
     FBodyInstance* InBody1,
     FBodyInstance* InBody2,
@@ -31,16 +31,15 @@ void UConstraintInstance::InitConstraint(
     {
         return;
     }
+
     Body1 = InBody1;
     Body2 = InBody2;
     JointName = Setup->JointName;
 
     PxRigidActor* PActor1 = Body1->RigidActor;
     PxRigidActor* PActor2 = Body2->RigidActor;
-
     PxTransform PLocalFrame1 = ToPxTransform(Setup->LocalFrame1);
     PxTransform PLocalFrame2 = ToPxTransform(Setup->LocalFrame2);
-
     PxD6Joint* D6Joint = PxD6JointCreate(*GPhysics,
         PActor1, PLocalFrame1,
         PActor2, PLocalFrame2
@@ -82,7 +81,7 @@ void UConstraintInstance::InitConstraint(
     bInitialized = true;
 }
 
-void UConstraintInstance::TermConstraint()
+void FConstraintInstance::TermConstraint()
 {
     if (bInitialized && Joint)
     {

--- a/EngineSIU/EngineSIU/ConstraintInstanceCore.h
+++ b/EngineSIU/EngineSIU/ConstraintInstanceCore.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "UObject/ObjectMacros.h"
+
+class UConstraintSetupCore;
+
+
+struct FConstraintInstanceCore
+{
+    DECLARE_STRUCT(FConstraintInstanceCore)
+
+public:
+    FConstraintInstanceCore() = default;
+    virtual ~FConstraintInstanceCore() = default;
+
+    FConstraintInstanceCore(const FConstraintInstanceCore&) = default;
+    FConstraintInstanceCore& operator=(const FConstraintInstanceCore&) = default;
+    FConstraintInstanceCore(FConstraintInstanceCore&&) = default;
+    FConstraintInstanceCore& operator=(FConstraintInstanceCore&&) = default;
+
+public:
+    TWeakObjectPtr<UConstraintSetupCore> ConstraintSetup;
+};

--- a/EngineSIU/EngineSIU/ConstraintSetup.h
+++ b/EngineSIU/EngineSIU/ConstraintSetup.h
@@ -11,7 +11,7 @@ struct FAngularConstraintLimit
 
 public:
 
-    float TwistLimitAngle = 45.f;
+    float TwistLimitAngle = 45.f; //x
     float Swing1LimitAngle = 45.f;
     float Swing2LimitAngle = 45.f;
 };

--- a/EngineSIU/EngineSIU/ConstraintSetup.h
+++ b/EngineSIU/EngineSIU/ConstraintSetup.h
@@ -25,8 +25,8 @@ public:
         : JointName(NAME_None)
         , ConstraintBone1(NAME_None)
         , ConstraintBone2(NAME_None)
-        , LocalFrame1(FTransform::Identity)
-        , LocalFrame2(FTransform::Identity)
+        , LocalFrame1(physx::PxTransform())
+        , LocalFrame2(physx::PxTransform())
         , bDisableCollisionBetweenConstrainedBodies(false)
     {    }
 
@@ -34,8 +34,8 @@ public:
     FName ConstraintBone1;
     FName ConstraintBone2;
 
-    FTransform LocalFrame1;
-    FTransform LocalFrame2;
+    physx::PxTransform LocalFrame1;
+    physx::PxTransform LocalFrame2;
 
     FAngularConstraintLimit AngularLimits;
 

--- a/EngineSIU/EngineSIU/ConstraintSetup.h
+++ b/EngineSIU/EngineSIU/ConstraintSetup.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "UObject/ObjectMacros.h"
+#include "Math/Transform.h"
+#include "PxPhysicsAPI.h" 
+#include "ConstraintSetupCore.h"
+
+struct FAngularConstraintLimit
+{
+    DECLARE_STRUCT(FAngularConstraintLimit)
+
+public:
+
+    float TwistLimitAngle = 45.f;
+    float Swing1LimitAngle = 45.f;
+    float Swing2LimitAngle = 45.f;
+};
+
+class UConstraintSetup : public UConstraintSetupCore
+{
+    DECLARE_CLASS(UConstraintSetup, UConstraintSetupCore)
+
+public:
+    UConstraintSetup()
+        : JointName(NAME_None)
+        , ConstraintBone1(NAME_None)
+        , ConstraintBone2(NAME_None)
+        , LocalFrame1(FTransform::Identity)
+        , LocalFrame2(FTransform::Identity)
+        , bDisableCollisionBetweenConstrainedBodies(false)
+    {    }
+
+    FName JointName; 
+    FName ConstraintBone1;
+    FName ConstraintBone2;
+
+    FTransform LocalFrame1;
+    FTransform LocalFrame2;
+
+    FAngularConstraintLimit AngularLimits;
+
+    bool bDisableCollisionBetweenConstrainedBodies;
+};

--- a/EngineSIU/EngineSIU/ConstraintSetupCore.cpp
+++ b/EngineSIU/EngineSIU/ConstraintSetupCore.cpp
@@ -1,0 +1,1 @@
+#include "ConstraintSetupCore.h"

--- a/EngineSIU/EngineSIU/ConstraintSetupCore.h
+++ b/EngineSIU/EngineSIU/ConstraintSetupCore.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "UObject/Object.h"
+#include "UObject/ObjectMacros.h"
+
+
+class UConstraintSetupCore : public UObject
+{
+    DECLARE_CLASS(UConstraintSetupCore, UObject)
+
+public:
+    UConstraintSetupCore() = default;
+    virtual ~UConstraintSetupCore() override = default;
+
+public:
+
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.cpp
@@ -1048,6 +1048,7 @@ void USkeletalMeshComponent::CreateRagDollFromPhysicsAsset()
         }
     }
 }
+
 void USkeletalMeshComponent::CalculateElement(UBodySetup* InBodySetup, int32 BoneIndex)
 {
     if (!InBodySetup)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.cpp
@@ -18,6 +18,10 @@
 #include "UObject/ObjectFactory.h"
 #include "PhysicsEngine/BodySetupCore.h"
 
+#include <iostream>
+#include <codecvt> 
+#include <string>  
+using namespace std;
 using namespace physx;
 
 extern PxFoundation* GFoundation;
@@ -78,6 +82,11 @@ void USkeletalMeshComponent::TickComponent(float DeltaTime)
 
 void USkeletalMeshComponent::PhysicsTick()
 {
+    if (BodyInstance.IsValidBodyInstance() && BodyInstance.IsSimulatingPhysics())
+    {
+        BodyInstance.SyncPhysXToComponent();
+    }
+
     if (bSimulatePhysics && Bodies.Num() > 0)
     {
         SyncBodiesToBones();
@@ -191,16 +200,10 @@ void USkeletalMeshComponent::SetSkeletalMeshAsset(USkeletalMesh* InSkeletalMeshA
 
     UPhysicsAsset* PhysAsset = new UPhysicsAsset();
     SkeletalMeshAsset->SetPhysicsAsset(PhysAsset);
-    // 하드코딩된 값으로 채워야 함.
+    PhysAsset->BodySetup.Empty();
+    PhysAsset->ConstraintSetup.Empty();
 
-
-    // Begin Test
-    //if (bRagDollSimulating)
-    //{
-    //    InitializeRagDoll(RefSkeleton);
-    //}
     InitializeRagDoll(RefSkeleton);
-    // End Test
 }
 
 FTransform USkeletalMeshComponent::GetSocketTransform(FName SocketName) const
@@ -428,7 +431,7 @@ void USkeletalMeshComponent::DestroyPhysicsState()
 void USkeletalMeshComponent::ClearPhysicsState()
 {
     // Constraints 먼저 해제 (Bodies를 참조할 수 있으므로)
-    for (UConstraintInstance* Constraint : Constraints)
+    for (FConstraintInstance* Constraint : Constraints)
     {
         if (Constraint)
         {
@@ -456,74 +459,11 @@ void USkeletalMeshComponent::InstantiatePhysicsAsset()
     {
         return;
     }
+
     UPhysicsAsset* PhysAsset = SkeletalMeshAsset->GetPhysicsAsset();
     const FReferenceSkeleton& RefSkeleton = SkeletalMeshAsset->GetSkeleton()->GetReferenceSkeleton();
+
     PopulatePhysicsAssetFromSkeleton(PhysAsset, RefSkeleton);
-
-    /*
-
-    // 1. Bodies 생성
-    Bodies.Reserve(PhysAsset->BodySetup.Num());
-    for (UBodySetup* Setup : PhysAsset->BodySetup)
-    {
-        if (Setup)
-        {
-            FBodyInstance* NewBodyInstance = new FBodyInstance();
-
-            // Setup->BoneName을 사용하여 이 BodySetup에 연결된 본의 인덱스를 찾고,
-            // 해당 본의 현재 월드 또는 컴포넌트 공간 트랜스폼을 가져옵니다.
-            // 이 부분은 스켈레탈 애니메이션 시스템과의 연동이 필요합니다.
-            FTransform BodyTransform = GetComponentTransform(); // 기본값: 컴포넌트 트랜스폼
-            int32 BoneIndex = SkeletalMeshAsset->GetSkeleton()->FindBoneIndex(Setup->BoneName);
-            if (BoneIndex != INDEX_NONE)
-            {
-                // 컴포넌트 공간 또는 월드 공간 트랜스폼 가져오기
-                BodyTransform = SkeletalMeshAsset->GetSkeleton()->GetReferenceSkeleton().GetRawRefBonePose()[BoneIndex]; 
-            }
-
-            NewBodyInstance->InitBody(this, Setup, BodyTransform, bSimulatePhysics);
-            Bodies.Add(NewBodyInstance);
-        }
-    }
-
-    // 2. Constraints 생성 (UPhysicsAsset에 ConstraintSetup 배열이 있다고 가정)
-    if (PhysAsset->ConstraintSetup.Num() > 0) // ConstraintSetups는 UPhysicsAsset의 TArray<UConstraintSetup*> 멤버라고 가정
-    {
-        Constraints.Reserve(PhysAsset->ConstraintSetup.Num());
-        for (UConstraintSetup* Setup : PhysAsset->ConstraintSetup)
-        {
-            if (Setup)
-            {
-                // ConstraintSetup에서 필요한 정보 (연결할 두 Body의 인덱스 또는 이름, 조인트 설정 등)를 가져옵니다.
-                // 해당 Body 인덱스를 사용하여 Bodies 배열에서 FBodyInstance 포인터를 찾습니다.
-                FBodyInstance* Body1 = nullptr;
-                FBodyInstance* Body2 = nullptr;
-
-                if (Setup->ConstraintBone1 != NAME_None && Setup->ConstraintBone2 != NAME_None)
-                {
-                    // ConstraintBone1과 ConstraintBone2는 UBodySetup의 BoneName과 일치하는 이름입니다.
-                    int32 BoneIndex1 = SkeletalMeshAsset->GetSkeleton()->FindBoneIndex(Setup->ConstraintBone1);
-                    int32 BoneIndex2 = SkeletalMeshAsset->GetSkeleton()->FindBoneIndex(Setup->ConstraintBone2);
-                    if (BoneIndex1 != INDEX_NONE && BoneIndex2 != INDEX_NONE)
-                    {
-                        // Bodies 배열에서 해당 본 인덱스에 해당하는 FBodyInstance를 찾습니다.
-                        Body1 = Bodies[BoneIndex1];
-                        Body2 = Bodies[BoneIndex2];
-                    }
-                    Setup->ConstraintBone1 = RefSkeleton.RawRefBoneInfo[BoneIndex1].Name;
-                    Setup->ConstraintBone2 = RefSkeleton.RawRefBoneInfo[BoneIndex2].Name;
-                }
-                
-                if (Body1 && Body2) // 두 Body가 모두 유효해야 조인트 생성 가능
-                {
-                    FConstraintInstance* NewConstraintInstance = new FConstraintInstance();
-                    NewConstraintInstance->InitConstraint(Setup, Body1, Body2, this, true);
-                    Constraints.Add(NewConstraintInstance);
-                }
-            }
-        }
-    }
-    */
 }
 
 void USkeletalMeshComponent::SyncBodiesToBones()
@@ -920,7 +860,6 @@ void USkeletalMeshComponent::InitializeRagDoll(const FReferenceSkeleton& InRefSk
     }
 
     UPhysicsAsset* PhysicsAsset = SkeletalMeshAsset->GetPhysicsAsset();
-    PhysicsAsset->BodySetup.Empty();
 
     for (int32 BoneIndex = 0; BoneIndex < InRefSkeleton.GetRawBoneNum(); BoneIndex++)
     {
@@ -930,7 +869,8 @@ void USkeletalMeshComponent::InitializeRagDoll(const FReferenceSkeleton& InRefSk
         FTransform ParentBoneTransform = FTransform::Identity;
         if (ParentIndex != -1)
         {
-            ParentBoneTransform = InRefSkeleton.GetRawRefBonePose()[ParentIndex].GetRelativeTransform(FTransform::Identity);
+            //ParentBoneTransform = InRefSkeleton.GetRawRefBonePose()[ParentIndex].GetRelativeTransform(FTransform::Identity);
+            ParentBoneTransform = InRefSkeleton.GetRawRefBonePose()[ParentIndex];
         }
 
         FTransform CurrentTransform = InRefSkeleton.GetRawRefBonePose()[BoneIndex].GetRelativeTransform(ParentBoneTransform);
@@ -942,50 +882,54 @@ void USkeletalMeshComponent::InitializeRagDoll(const FReferenceSkeleton& InRefSk
         ///// Begin Test
         UBodySetup* NewBodySetup = FObjectFactory::ConstructObject<UBodySetup>(PhysicsAsset);
         NewBodySetup->AggGeom.SphylElems.AddDefaulted();
+
+        CalculateElement(NewBodySetup, InRefSkeleton, BoneIndex);
+
         PhysicsAsset->BodySetup.Add(NewBodySetup);
+
     }
 }
 
-void USkeletalMeshComponent::CreateRagDoll(const PxVec3& WorldRoot)
-{
-    for (int i = 0; i < RagdollBones.Num(); ++i)
-    {
-        RagdollBone& bone = RagdollBones[i];
-
-        // 부모의 위치 기준으로 위치 계산
-        PxVec3 parentPos = (bone.parentIndex >= 0) ? RagdollBones[bone.parentIndex].body->getGlobalPose().p : WorldRoot;
-        PxVec3 bonePos = parentPos + bone.offset;
-
-        // 바디 생성
-        PxTransform pose(bonePos);
-        PxRigidDynamic* body = GPhysics->createRigidDynamic(pose);
-        PxShape* shape = GPhysics->createShape(PxCapsuleGeometry(bone.halfSize.x, bone.halfSize.y), *GMaterial);
-        body->attachShape(*shape);
-        PxRigidBodyExt::updateMassAndInertia(*body, 1.0f);
-        GScene->addActor(*body);
-        bone.body = body;
-
-        // 조인트 연결
-        if (bone.parentIndex >= 0)
-        {
-            RagdollBone& parent = RagdollBones[bone.parentIndex];
-
-            PxTransform localFrameParent = PxTransform(parent.body->getGlobalPose().getInverse() * PxTransform(bonePos));
-            PxTransform localFrameChild = PxTransform(PxVec3(0));
-
-            PxD6Joint* joint = PxD6JointCreate(*GPhysics, parent.body, localFrameParent, bone.body, localFrameChild);
-
-            // 각도 제한 설정
-            joint->setMotion(PxD6Axis::eTWIST, PxD6Motion::eLIMITED);
-            joint->setMotion(PxD6Axis::eSWING1, PxD6Motion::eLIMITED);
-            joint->setMotion(PxD6Axis::eSWING2, PxD6Motion::eLIMITED);
-            joint->setTwistLimit(PxJointAngularLimitPair(-PxPi / 4, PxPi / 4));
-            joint->setSwingLimit(PxJointLimitCone(PxPi / 6, PxPi / 6));
-
-            bone.joint = joint;
-        }
-    }
-}
+//void USkeletalMeshComponent::CreateRagDoll(const PxVec3& WorldRoot)
+//{
+//    for (int i = 0; i < RagdollBones.Num(); ++i)
+//    {
+//        RagdollBone& bone = RagdollBones[i];
+//
+//        // 부모의 위치 기준으로 위치 계산
+//        PxVec3 parentPos = (bone.parentIndex >= 0) ? RagdollBones[bone.parentIndex].body->getGlobalPose().p : WorldRoot;
+//        PxVec3 bonePos = parentPos + bone.offset;
+//
+//        // 바디 생성
+//        PxTransform pose(bonePos);
+//        PxRigidDynamic* body = GPhysics->createRigidDynamic(pose);
+//        PxShape* shape = GPhysics->createShape(PxCapsuleGeometry(bone.halfSize.x, bone.halfSize.y), *GMaterial);
+//        body->attachShape(*shape);
+//        PxRigidBodyExt::updateMassAndInertia(*body, 1.0f);
+//        GScene->addActor(*body);
+//        bone.body = body;
+//
+//        // 조인트 연결
+//        if (bone.parentIndex >= 0)
+//        {
+//            RagdollBone& parent = RagdollBones[bone.parentIndex];
+//
+//            PxTransform localFrameParent = PxTransform(parent.body->getGlobalPose().getInverse() * PxTransform(bonePos));
+//            PxTransform localFrameChild = PxTransform(PxVec3(0));
+//
+//            PxD6Joint* joint = PxD6JointCreate(*GPhysics, parent.body, localFrameParent, bone.body, localFrameChild);
+//
+//            // 각도 제한 설정
+//            joint->setMotion(PxD6Axis::eTWIST, PxD6Motion::eLIMITED);
+//            joint->setMotion(PxD6Axis::eSWING1, PxD6Motion::eLIMITED);
+//            joint->setMotion(PxD6Axis::eSWING2, PxD6Motion::eLIMITED);
+//            joint->setTwistLimit(PxJointAngularLimitPair(-PxPi / 4, PxPi / 4));
+//            joint->setSwingLimit(PxJointLimitCone(PxPi / 6, PxPi / 6));
+//
+//            bone.joint = joint;
+//        }
+//    }
+//}
 
 void USkeletalMeshComponent::DestroyRagDoll()
 {
@@ -996,23 +940,23 @@ void USkeletalMeshComponent::UpdateRagdoll()
 {
     if (bRagDollSimulating)
     {
-        //for (auto& bone : RagdollBones)
+        //for (auto Body : Bodies)
         //{
-        //    PxTransform t = bone.body->getGlobalPose();
+        //    FVector Location = Body->GetWorldTransform().GetLocation();
+        //    PxTransform t = { Location.X, Location.Y, Location.Z };
         //    PxMat44 m(t);
         //}
-        for (auto Body : Bodies)
-        {
-            FVector Location = Body->GetWorldTransform().GetLocation();
-            PxTransform t = { Location.X, Location.Y, Location.Z };
-            PxMat44 m(t);
-        }
-        for (auto Constraint : Constraints)
-        {
-            //FVector Location = Constraint->GetWorldTransform().GetLocation();
-            //PxTransform t = { Location.X, Location.Y, Location.Z };
-            //PxMat44 m(t);
-        }
+        //for (auto Constraint : Constraints)
+        //{
+        //    //FVector Location = Constraint->GetWorldTransform().GetLocation();
+        //    //PxTransform t = { Location.X, Location.Y, Location.Z };
+        //    //PxMat44 m(t);
+        //}
+
+        UPhysicsAsset* PhysAsset = SkeletalMeshAsset->GetPhysicsAsset();
+        const FReferenceSkeleton& RefSkeleton = SkeletalMeshAsset->GetSkeleton()->GetReferenceSkeleton();
+
+        PopulatePhysicsAssetFromSkeleton(PhysAsset, RefSkeleton);
     }
 }
 
@@ -1021,10 +965,8 @@ void USkeletalMeshComponent::BeginPlay()
     Super::BeginPlay();
 
     CreatePhysicsState();
-
-    //FVector test = this->GetRelativeTransform().GetLocation();
-    //CreateRagDoll({ test.X, test.Y, test.Z }); // 월드 루트 위치를 기준으로 시작);
     CreateRagDollFromPhysicsAsset();
+
 }
 
 void USkeletalMeshComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
@@ -1042,46 +984,26 @@ void USkeletalMeshComponent::PopulatePhysicsAssetFromSkeleton(UPhysicsAsset* Phy
         return;
     }
 
-    PhysicsAssetToPopulate->BodySetup.Empty();
-    PhysicsAssetToPopulate->ConstraintSetup.Empty(); // Constraint 설정도 초기화
-
-    // 1. BodySetups 생성
+    // Begin Body
     for (int32 BoneIndex = 0; BoneIndex < InRefSkeleton.GetRawBoneNum(); ++BoneIndex)
     {
         const FMeshBoneInfo& BoneInfo = InRefSkeleton.GetRawRefBoneInfo()[BoneIndex];
-        const FTransform& BoneLocalTransform = InRefSkeleton.GetRawRefBonePose()[BoneIndex]; // 본의 로컬 (부모 상대) 트랜스폼
 
-        UBodySetup* NewBodySetup = FObjectFactory::ConstructObject<UBodySetup>(PhysicsAssetToPopulate); // Outer를 PhysicsAsset으로
+        // UBodySetup* NewBodySetup = FObjectFactory::ConstructObject<UBodySetup>(PhysicsAssetToPopulate);
+        UBodySetup* NewBodySetup = FObjectFactory::ConstructObject<UBodySetup>(PhysicsAssetToPopulate, BoneInfo.Name);
         NewBodySetup->BoneName = BoneInfo.Name;
+        NewBodySetup->bOverrideMass = true;
+        NewBodySetup->Mass = DefaultBodyMass;
+        NewBodySetup->LinearDamping = 0.05f;
+        NewBodySetup->AngularDamping = 0.05f;
 
-        // --- 콜리전 모양 및 크기 설정 (예시: 캡슐) ---
-        FKSphylElem CapsuleElem;
-        CapsuleElem.Center = FVector::ZeroVector; // BodySetup 내의 콜리전은 본에 상대적이므로 보통 (0,0,0) 에서 시작
-        // 실제 오프셋은 BodySetup의 트랜스폼이나, 본 자체의 트랜스폼으로 관리됨.
-        // 또는 본 길이의 절반 지점에 위치시킬 수 있음.
-
-        // 본의 길이와 두께를 기반으로 캡슐 크기 결정 (이 부분은 매우 단순화된 예시)
-        float BoneLength = 50.0f; // 실제로는 자식 본 위치나 특정 로직으로 계산
-        float Radius = 10.0f;    // 적절한 반지름 값
-
-        // 다음 본과의 거리로 길이를 추정하거나, 스켈레톤 데이터에서 직접 가져올 수 있다면 더 좋음
-        if (BoneIndex + 1 < InRefSkeleton.GetRawBoneNum() && InRefSkeleton.GetRawRefBoneInfo()[BoneIndex + 1].ParentIndex == BoneIndex)
-        {
-            BoneLength = FVector::Dist(BoneLocalTransform.GetLocation(), InRefSkeleton.GetRawRefBonePose()[BoneIndex + 1].GetLocation());
-        }
-        CapsuleElem.Length = BoneLength - (2 * Radius); // 실제 캡슐 몸통 길이
-        CapsuleElem.Radius = Radius;
-        // 캡슐 방향 설정: PhysX 캡슐은 기본적으로 X축을 따라 생성. 본의 주축에 맞춰 회전 필요.
-        // 여기서는 Z축을 향한다고 가정하고 회전 (엔진 좌표계에 따라 다름)
-        CapsuleElem.Rotation = FRotator(90.f, 0.f, 0.f); // 예: Z축으로 세우기 위해 X축 90도 회전
-
-        NewBodySetup->AggGeom.SphylElems.Add(CapsuleElem);
-        // --- 콜리전 설정 끝 ---
-
+        CalculateElement(NewBodySetup, InRefSkeleton, BoneIndex);
         PhysicsAssetToPopulate->BodySetup.Add(NewBodySetup);
     }
-
-    // 2. ConstraintSetups 생성
+    // End Body
+     
+    //// FIX-ME
+    // Begin Constraint
     for (int32 BoneIndex = 0; BoneIndex < InRefSkeleton.GetRawBoneNum(); ++BoneIndex)
     {
         const FMeshBoneInfo& BoneInfo = InRefSkeleton.GetRawRefBoneInfo()[BoneIndex];
@@ -1089,29 +1011,29 @@ void USkeletalMeshComponent::PopulatePhysicsAssetFromSkeleton(UPhysicsAsset* Phy
         {
             const FMeshBoneInfo& ParentBoneInfo = InRefSkeleton.GetRawRefBoneInfo()[BoneInfo.ParentIndex];
 
-            UConstraintSetup* NewConstraintSetup= new UConstraintSetup();
-            NewConstraintSetup->JointName = FName(*(BoneInfo.Name.ToString() + TEXT("_joint_") + ParentBoneInfo.Name.ToString()));
+            //UConstraintSetup* NewConstraintSetup = FObjectFactory::ConstructObject<UConstraintSetup>(PhysicsAssetToPopulate);
+            UConstraintSetup* NewConstraintSetup = FObjectFactory::ConstructObject<UConstraintSetup>(PhysicsAssetToPopulate, FName(*(BoneInfo.Name.ToString() + TEXT("_joint"))));
+            NewConstraintSetup->JointName = FName(*(BoneInfo.Name.ToString() + TEXT("_joint_") + ParentBoneInfo.Name.ToString())); // 좀 더 상세한 이름
             NewConstraintSetup->ConstraintBone1 = ParentBoneInfo.Name; // 부모 본
             NewConstraintSetup->ConstraintBone2 = BoneInfo.Name;   // 자식 본
+ 
+            const FTransform& ParentRefPose_ComponentSpace = InRefSkeleton.GetRawRefBonePose()[BoneInfo.ParentIndex];
+            const FTransform& ChildRefPose_ComponentSpace = InRefSkeleton.GetRawRefBonePose()[BoneIndex];
+            NewConstraintSetup->LocalFrame1 = ChildRefPose_ComponentSpace * ParentRefPose_ComponentSpace.Inverse();
+            NewConstraintSetup->LocalFrame2 = FTransform::Identity;
 
-            // 로컬 프레임 설정: 조인트의 위치와 방향을 각 본의 로컬 공간에서 정의
-            // 예: 부모 본의 끝, 자식 본의 시작 부분에 조인트 위치
-            //    이 값들은 PhysicsAsset 에디터에서 튜닝하는 것이 일반적임.
-            //    여기서는 간단히 Identity로 설정 (실제로는 매우 중요하고 복잡한 부분)
-            NewConstraintSetup->LocalFrame1 = FTransform::Identity; // ParentBone의 로컬 공간에서의 조인트 프레임
-            NewConstraintSetup->LocalFrame2 = FTransform::Identity; // ChildBone의 로컬 공간에서의 조인트 프레임
-
-            // 각도 제한 설정 (예시)
             NewConstraintSetup->AngularLimits.TwistLimitAngle = 45.f;
             NewConstraintSetup->AngularLimits.Swing1LimitAngle = 30.f;
             NewConstraintSetup->AngularLimits.Swing2LimitAngle = 30.f;
+            NewConstraintSetup->bDisableCollisionBetweenConstrainedBodies = true; // 기본적으로 연결된 바디끼리 충돌 안함
 
             PhysicsAssetToPopulate->ConstraintSetup.Add(NewConstraintSetup);
         }
     }
+    // End Constraint
 }
 
-void USkeletalMeshComponent::CreateRagDollFromPhysicsAsset() 
+void USkeletalMeshComponent::CreateRagDollFromPhysicsAsset()
 {
     if (!(SkeletalMeshAsset && SkeletalMeshAsset->GetPhysicsAsset() && SkeletalMeshAsset->GetSkeleton() && GetWorld()))
     {
@@ -1121,7 +1043,7 @@ void USkeletalMeshComponent::CreateRagDollFromPhysicsAsset()
     UPhysicsAsset* PhysAsset = SkeletalMeshAsset->GetPhysicsAsset();
     USkeleton* CurrentSkeleton = SkeletalMeshAsset->GetSkeleton();
 
-    ClearPhysicsState(); 
+    ClearPhysicsState();
 
     TMap<FName, FBodyInstance*> BoneNameToBodyInstanceMap;
     Bodies.Reserve(PhysAsset->BodySetup.Num());
@@ -1136,41 +1058,93 @@ void USkeletalMeshComponent::CreateRagDollFromPhysicsAsset()
             int32 BoneIdx = CurrentSkeleton->FindBoneIndex(Setup->BoneName);
             if (BoneIdx != INDEX_NONE)
             {
-                BoneRefPoseGlobalTransform = CurrentSkeleton->GetReferenceSkeleton().GetRawRefBonePose()[BoneIdx];
+                BoneRefPoseGlobalTransform = GetComponentTransform() * CurrentSkeleton->GetReferenceSkeleton().GetRawRefBonePose()[BoneIdx];
             }
 
-
-            // InitBody는 bSimulatePhysics=true로 호출되어야 래그돌처럼 동작 (PxRigidDynamic 생성)
             NewBodyInstance->InitBody(this, Setup, BoneRefPoseGlobalTransform, true /*bSimulatePhysics*/);
             Bodies.Add(NewBodyInstance);
             BoneNameToBodyInstanceMap.Add(Setup->BoneName, NewBodyInstance);
-
-            // 생성된 PxRigidDynamic을 RagdollBones와 유사한 구조에 저장할 수도 있지만,
-            // FBodyInstance가 PxRigidActor를 이미 가지고 있음.
         }
     }
 
-    // 3. PhysicsAsset의 ConstraintSetups로부터 FConstraintInstance (및 PxJoint) 생성
-    Constraints.Reserve(PhysAsset->ConstraintSetup.Num());
+    //// FIX-ME
+    // Begin Constraint
     for (const auto CSSetup : PhysAsset->ConstraintSetup)
     {
-        FBodyInstance* BodyInst1 = *BoneNameToBodyInstanceMap.Find(CSSetup->ConstraintBone1);
-        FBodyInstance* BodyInst2 = *BoneNameToBodyInstanceMap.Find(CSSetup->ConstraintBone2);
+        FBodyInstance** PtrBodyInst1 = BoneNameToBodyInstanceMap.Find(CSSetup->ConstraintBone1);
+        FBodyInstance** PtrBodyInst2 = BoneNameToBodyInstanceMap.Find(CSSetup->ConstraintBone2);
 
-        const FReferenceSkeleton& RefSkeleton = GetSkeletalMeshAsset()->GetSkeleton()->GetReferenceSkeleton();
-        CSSetup->LocalFrame1 = RefSkeleton.GetRawRefBonePose()[RefSkeleton.FindBoneIndex(CSSetup->ConstraintBone1)];
-        CSSetup->LocalFrame2 = RefSkeleton.GetRawRefBonePose()[RefSkeleton.FindBoneIndex(CSSetup->ConstraintBone2)];
-
-        if (BodyInst1 && BodyInst2)
+        if (PtrBodyInst1 && PtrBodyInst2)
         {
+            FBodyInstance* BodyInst1 = *PtrBodyInst1;
+            FBodyInstance* BodyInst2 = *PtrBodyInst2;
+
             if (BodyInst1 && BodyInst2 && BodyInst1->RigidActor && BodyInst2->RigidActor)
             {
-                UConstraintInstance* NewConstraintInstance = new UConstraintInstance();
-                // InitConstraint는 FConstraintSetup을 직접 받도록 수정했었음
-                NewConstraintInstance->InitConstraint(CSSetup, BodyInst1, BodyInst2, this, true /*bSimulatePhysics*/);
+                FConstraintInstance* NewConstraintInstance = new FConstraintInstance();
+                NewConstraintInstance->InitConstraint(CSSetup, BodyInst1, BodyInst2, this, true);
                 Constraints.Add(NewConstraintInstance);
             }
         }
     }
-    // SetSimulatePhysics(true); // 컴포넌트 전체에 대한 플래그. 이미 개별 BodyInstance 생성 시 반영.
+    // End Constraint
+}
+
+void USkeletalMeshComponent::CalculateElement(UBodySetup* InBodySetup, const FReferenceSkeleton& InRefSkeleton, int32 BoneIndex)
+{
+    FKSphylElem CapsuleElem;
+    CapsuleElem.Center = InRefSkeleton.GetRawRefBonePose()[BoneIndex].GetLocation(); // 본의 로컬 원점을 기준으로 콜리전 위치 지정
+
+    float EstimatedBoneLength = -1.0f;
+    FVector ChildDirection = FVector::ForwardVector; // 기본 방향 (예: X축)
+
+    for (int32 ChildSearchIdx = 0; ChildSearchIdx < InRefSkeleton.GetRawBoneNum(); ++ChildSearchIdx)
+    {
+        if (InRefSkeleton.GetRawRefBoneInfo()[ChildSearchIdx].ParentIndex == BoneIndex)
+        {
+            FVector ChildLocalPos = InRefSkeleton.GetRawRefBonePose()[ChildSearchIdx].GetLocation();
+            EstimatedBoneLength = ChildLocalPos.Size();
+            if (EstimatedBoneLength > KINDA_SMALL_NUMBER)
+            {
+                ChildDirection = ChildLocalPos.GetSafeNormal();
+            }
+            break;
+        }
+    }
+
+    if (EstimatedBoneLength <= KINDA_SMALL_NUMBER)
+    {
+        EstimatedBoneLength = DefaultBoneLength;
+    }
+
+    CalculatedRadius = FMath::Max(MinRadius, EstimatedBoneLength * 0.25f);
+
+    CalculatedCylinderLength = EstimatedBoneLength - (2.0f * CalculatedRadius);
+
+    if (CalculatedCylinderLength < MinCylinderLength)
+    {
+        CalculatedRadius = FMath::Max(MinRadius, (EstimatedBoneLength - MinCylinderLength) / 2.0f);
+        CalculatedCylinderLength = FMath::Max(MinCylinderLength, EstimatedBoneLength - (2.0f * CalculatedRadius));
+
+        if (CalculatedCylinderLength < MinCylinderLength || CalculatedRadius < MinRadius)
+        {
+            CalculatedRadius = MinRadius;
+            CalculatedCylinderLength = MinCylinderLength;
+        }
+    }
+
+    CapsuleElem.Radius = FMath::Clamp(CalculatedRadius, MinRadius, MaxRadius);
+    CapsuleElem.Length = CalculatedCylinderLength;
+
+    if (ChildDirection.IsNearlyZero() || ChildDirection.Equals(FVector::ForwardVector))
+    {
+        CapsuleElem.Rotation = FRotator::ZeroRotator;
+    }
+    else
+    {
+        FQuat RotQuat = FQuat::FindBetween(FVector::ForwardVector, ChildDirection);
+        CapsuleElem.Rotation = RotQuat.Rotator();
+    }
+
+    InBodySetup->AggGeom.SphylElems.Add(CapsuleElem);
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.cpp
@@ -82,16 +82,21 @@ void USkeletalMeshComponent::TickComponent(float DeltaTime)
 
 void USkeletalMeshComponent::PhysicsTick()
 {
-    if (BodyInstance.IsValidBodyInstance() && BodyInstance.IsSimulatingPhysics())
-    {
-        BodyInstance.SyncPhysXToComponent();
-    }
+    Super::PhysicsTick();
 
     if (bSimulatePhysics && Bodies.Num() > 0)
     {
         SyncBodiesToBones();
-        UpdateRagdoll();
     }
+
+
+    //for (auto body : Bodies)
+    //{
+    //    if (body->IsValidBodyInstance() && body->IsSimulatingPhysics())
+    //    {
+    //        body->SyncPhysXToComponent();
+    //    }
+    //}
 }
 
 void USkeletalMeshComponent::TickPose(float DeltaTime)
@@ -471,108 +476,98 @@ void USkeletalMeshComponent::InstantiatePhysicsAsset()
     {
         return;
     }
-
-    //UPhysicsAsset* PhysAsset = SkeletalMeshAsset->GetPhysicsAsset();
-    //PopulatePhysicsAssetFromSkeleton(PhysAsset);
 }
 
 void USkeletalMeshComponent::SyncBodiesToBones()
 {
-    // 이 함수는 물리 시뮬레이션이 완료된 후 (FPhysX::Tick 이후) 호출되어야 합니다.
-    // 그리고 bSimulatePhysics가 true일 때만 의미가 있습니다.
-
     if (!bSimulatePhysics || Bodies.Num() == 0)
     {
         return;
     }
 
     UPhysicsAsset* CurrentPhysicsAsset = SkeletalMeshAsset->GetPhysicsAsset();
-    USkeletalMesh* CurrentSkeletalMesh = GetSkeletalMeshAsset(); // 또는 멤버 변수 직접 사용
+    USkeletalMesh* CurrentSkeletalMesh = GetSkeletalMeshAsset();
 
     if (!CurrentPhysicsAsset || !CurrentSkeletalMesh || !CurrentSkeletalMesh->GetSkeleton())
     {
-        // 필요한 에셋 정보가 없으면 동기화 불가
-        // UE_LOG(LogSkeletalMesh, Warning, TEXT("SyncBodiesToBones: Missing PhysicsAsset, SkeletalMesh, or Skeleton."));
         return;
     }
 
     USkeleton* Skeleton = CurrentSkeletalMesh->GetSkeleton();
+    const int32 NumBones = RagdollBones.Num();
 
-    // 컴포넌트의 현재 월드 트랜스폼 (본 트랜스폼을 컴포넌트 공간으로 변환 시 필요)
-    // const FTransform ComponentToWorldInverse = GetComponentToWorld().Inverse();
+    const FTransform ComponentToWorld = GetComponentTransform();
+    const FTransform WorldToComponent = ComponentToWorld.Inverse();
+
+    TMap<int32, FTransform> SimulatedBoneWorldTransforms;
 
     for (int32 BodyInstanceIndex = 0; BodyInstanceIndex < Bodies.Num(); ++BodyInstanceIndex)
     {
         FBodyInstance* BodyInst = Bodies[BodyInstanceIndex];
-
-        // 해당 FBodyInstance에 대한 UBodySetup 정보 가져오기
-        // (PhysicsAsset의 BodySetup 배열과 Bodies 배열의 인덱스가 일치한다고 가정)
-        if (BodyInstanceIndex >= CurrentPhysicsAsset->BodySetup.Num())
-        {
-            // UE_LOG(LogSkeletalMesh, Warning, TEXT("SyncBodiesToBones: BodyInstanceIndex out of bounds for PhysicsAsset BodySetups."));
-            continue;
-        }
+        if (BodyInstanceIndex >= CurrentPhysicsAsset->BodySetup.Num()) continue;
         UBodySetup* AssociatedBodySetup = CurrentPhysicsAsset->BodySetup[BodyInstanceIndex];
 
         if (BodyInst && BodyInst->IsValidBodyInstance() && BodyInst->IsSimulatingPhysics() && AssociatedBodySetup)
         {
-            FName BoneName = AssociatedBodySetup->BoneName; // UBodySetup에서 본 이름 가져오기
-            if (BoneName == NAME_None)
-            {
-                // 이 BodySetup이 특정 본에 연결되지 않았다면 (예: 전체를 감싸는 하나의 바디),
-                // 컴포넌트 자체의 트랜스폼을 업데이트하거나 다른 처리를 할 수 있음.
-                // 여기서는 본에 연결된 경우만 처리.
-                continue;
-            }
+            FName BoneName = AssociatedBodySetup->BoneName;
+            if (BoneName == NAME_None) continue;
 
-            // 본 인덱스 확인
             int32 BoneIndex = Skeleton->FindBoneIndex(BoneName);
-            if (BoneIndex == INDEX_NONE)
-            {
-                // UE_LOG(LogSkeletalMesh, Warning, TEXT("SyncBodiesToBones: Bone '%s' not found in Skeleton."), *BoneName.ToString());
-                continue;
-            }
+            if (BoneIndex == INDEX_NONE) continue;
 
-            // 1. FBodyInstance로부터 PhysX Actor의 현재 월드 트랜스폼을 가져옵니다.
             FTransform PhysXWorldTransform = BodyInst->GetWorldTransform();
-
-            // 2. 가져온 월드 트랜스폼을 해당 본에 직접 설정합니다.
-            //    이 작업은 애니메이션 결과를 덮어쓰게 됩니다.
-            //    SetBoneWorldSpaceTransform 함수가 있다고 가정.
-            //    이 함수는 내부적으로 다른 자식 본들의 상대적 위치도 업데이트해야 할 수 있음 (Forward Kinematics).
-            //    또는, 단순히 해당 본의 공간 변환 정보만 업데이트하고,
-            //    메시 디포메이션은 나중에 전체 본 계층 구조를 기반으로 수행될 수 있음.
-
-            // 예시: 가상의 SetBoneWorldTransform 함수 호출
-            // SetBoneWorldTransform(BoneIndex, PhysXWorldTransform);
-            // 또는
-            // SetBoneTransformByName(BoneName, PhysXWorldTransform, EBoneSpaces::WorldSpace);
-
-            // 만약 본 트랜스폼을 컴포넌트 공간으로 설정해야 한다면:
-            // FTransform BoneComponentSpaceTransform = PhysXWorldTransform * ComponentToWorldInverse;
-            // SetBoneTransformByName(BoneName, BoneComponentSpaceTransform, EBoneSpaces::ComponentSpace);
-
-            // UE_LOG(LogSkeletalMesh, Verbose, TEXT("Bone '%s' (Index %d) synced to PhysX Transform: %s"),
-            //     *BoneName.ToString(), BoneIndex, *PhysXWorldTransform.ToString());
-
-
-            // 실제 언리얼 엔진에서는 이 과정이 더 복잡합니다.
-            // - SpaceBases (로컬 공간), BoneSpaceTransforms (컴포넌트 공간) 등을 업데이트.
-            // - Kinematic 본과 Simulated 본을 구분하여 처리.
-            // - 텔레포트 여부, 물리 블렌딩 가중치 등을 고려.
-            // - `FillComponentSpaceTransforms()` 같은 함수를 통해 최종 컴포넌트 공간 변환 배열을 채움.
-
-            // 여기서는 가장 기본적인 "물리 결과를 본의 월드 트랜스폼으로 직접 적용"하는 로직을 가정합니다.
-            // 사용자 엔진의 스켈레탈 애니메이션 시스템 구조에 맞춰 구체적인 본 트랜스폼 설정 방식을 구현해야 합니다.
-            // 예를 들어, 각 본의 FMatrix 또는 FTransform 배열을 직접 업데이트할 수 있습니다.
-            // GetEditableBoneTransform(BoneIndex).SetFromMatrix(PhysXWorldTransform.ToMatrixWithScale());
+            SimulatedBoneWorldTransforms.Add(BoneIndex, PhysXWorldTransform);
         }
     }
 
-    // 모든 물리 본의 트랜스폼이 업데이트된 후,
-    // 컴포넌트의 최종 바운딩 박스 등을 다시 계산해야 할 수 있습니다.
-    // MarkRenderTransformDirty(); // 렌더링 시스템에 트랜스폼 변경 알림
-    // UpdateBounds(); // 바운딩 볼륨 업데이트
+    for (int32 BoneIndex = 0; BoneIndex < NumBones; ++BoneIndex)
+    {
+        if (SimulatedBoneWorldTransforms.Contains(BoneIndex))
+        {
+            FTransform NewWorldTransform = SimulatedBoneWorldTransforms[BoneIndex];
+            FTransform NewLocalTransform;
+
+            int32 ParentIndex = RagdollBones[BoneIndex].parentIndex;
+
+            if (ParentIndex == INDEX_NONE)
+            {
+                NewLocalTransform = NewWorldTransform * WorldToComponent;
+            }
+            else
+            {
+                FTransform ParentWorldTransform;
+                if (SimulatedBoneWorldTransforms.Contains(ParentIndex))
+                {
+                    ParentWorldTransform = SimulatedBoneWorldTransforms[ParentIndex];
+                }
+                else
+                {
+                    TArray<FTransform> TempBoneSpaceTransforms;
+                    TempBoneSpaceTransforms.SetNum(NumBones);
+                    for (int32 i = 0; i < NumBones; ++i)
+                    {
+                        const FTransform& BoneLocalSpace = BonePoseContext.Pose[i];
+                        int32 CurrentParentIdx = RagdollBones[i].parentIndex;
+                        if (CurrentParentIdx == INDEX_NONE)
+                        {
+                            TempBoneSpaceTransforms[i] = BoneLocalSpace;
+                        }
+                        else
+                        {
+                            TempBoneSpaceTransforms[i] = BoneLocalSpace * TempBoneSpaceTransforms[CurrentParentIdx];
+                        }
+                    }
+                    ParentWorldTransform = TempBoneSpaceTransforms[ParentIndex] * ComponentToWorld;
+                }
+
+                NewLocalTransform = NewWorldTransform.GetRelativeTransform(ParentWorldTransform);
+            }
+
+            BonePoseContext.Pose[BoneIndex] = NewLocalTransform;
+        }
+    }
+    // MarkRenderStateDirty(); // 렌더링 상태 변경 알림 (본 트랜스폼이 바뀌었으므로)
+    // UpdateBounds();       // 바운딩 볼륨 업데이트
 }
 
 void USkeletalMeshComponent::CPUSkinning(bool bForceUpdate)
@@ -861,10 +856,13 @@ void USkeletalMeshComponent::SetLoopEndFrame(int32 InLoopEndFrame)
         SingleNodeInstance->SetLoopEndFrame(InLoopEndFrame);
     }
 }
-
 void USkeletalMeshComponent::InitializeRagDoll(const FReferenceSkeleton& InRefSkeleton)
 {
-    if (InRefSkeleton.GetRawBoneNum() == 0 || !SkeletalMeshAsset || !SkeletalMeshAsset->GetPhysicsAsset())
+    if (InRefSkeleton.GetRawBoneNum() == 0)
+    {
+        return;
+    }
+    if (!SkeletalMeshAsset)
     {
         return;
     }
@@ -872,7 +870,7 @@ void USkeletalMeshComponent::InitializeRagDoll(const FReferenceSkeleton& InRefSk
     UPhysicsAsset* PhysicsAssetToPopulate = SkeletalMeshAsset->GetPhysicsAsset();
     if (!PhysicsAssetToPopulate)
     {
-        return;
+        return; 
     }
 
     RagdollBones.Empty();
@@ -887,38 +885,11 @@ void USkeletalMeshComponent::InitializeRagDoll(const FReferenceSkeleton& InRefSk
         CurrentRagdollBone.parentIndex = MeshBoneInfo.ParentIndex;
 
         FTransform BoneLocalTransform = InRefSkeleton.GetRawRefBonePose()[BoneIndex];
-        if (MeshBoneInfo.ParentIndex != INDEX_NONE)
-        {
-            BoneLocalTransform = InRefSkeleton.GetRawRefBonePose()[BoneIndex];
-        }
-        CurrentRagdollBone.offset = PxVec3(BoneLocalTransform.GetLocation().X, BoneLocalTransform.GetLocation().Y, BoneLocalTransform.GetLocation().Z);
+        CurrentRagdollBone.offset = PxVec3(BoneLocalTransform.GetLocation().X,
+            BoneLocalTransform.GetLocation().Y,
+            BoneLocalTransform.GetLocation().Z);
 
-        float EstimatedBoneLength = DefaultBoneLength;
-        bool bHasChild = false;
-        for (int32 ChildSearchIdx = 0; ChildSearchIdx < InRefSkeleton.GetRawBoneNum(); ++ChildSearchIdx)
-        {
-            if (InRefSkeleton.GetRawRefBoneInfo()[ChildSearchIdx].ParentIndex == BoneIndex)
-            {
-                FVector ChildLocalPos = InRefSkeleton.GetRawRefBonePose()[ChildSearchIdx].GetLocation();
-                EstimatedBoneLength = ChildLocalPos.Size();
-                bHasChild = true;
-                break;
-            }
-        }
-        if (!bHasChild && MeshBoneInfo.ParentIndex != INDEX_NONE)
-        {
-            EstimatedBoneLength = DefaultBoneLength * 0.5f;
-        }
-
-
-        float Radius = FMath::Clamp(EstimatedBoneLength * 0.25f, MinRadius, MaxRadius);
-        float HalfHeight = FMath::Max(MinCylinderLength, EstimatedBoneLength - (2.0f * Radius)) / 2.0f;
-        if (HalfHeight < MinCylinderLength / 2.0f)
-        {
-            Radius = FMath::Max(MinRadius, (EstimatedBoneLength - MinCylinderLength) / 2.0f);
-            HalfHeight = FMath::Max(MinCylinderLength / 2.0f, (EstimatedBoneLength - (2.0f * Radius)) / 2.0f);
-        }
-        CurrentRagdollBone.halfSize = physx::PxVec3(Radius, HalfHeight, Radius); // PxCapsuleGeometry (radius, halfHeight)
+        // CurrentRagdollBone.halfSize = physx::PxVec3(0.f); // 필요하다면 초기화
     }
 
     PopulatePhysicsAssetFromSkeleton(PhysicsAssetToPopulate, InRefSkeleton);
@@ -927,16 +898,6 @@ void USkeletalMeshComponent::InitializeRagDoll(const FReferenceSkeleton& InRefSk
 void USkeletalMeshComponent::DestroyRagDoll()
 {
     RagdollBones.Empty();
-}
-void USkeletalMeshComponent::UpdateRagdoll()
-{
-    if (bRagDollSimulating)
-    {
-        UPhysicsAsset* PhysicsAsset = SkeletalMeshAsset->GetPhysicsAsset();
-        const FReferenceSkeleton& RefSkeleton = SkeletalMeshAsset->GetSkeleton()->GetReferenceSkeleton();
-
-        PopulatePhysicsAssetFromSkeleton(PhysicsAsset, RefSkeleton);
-    }
 }
 
 void USkeletalMeshComponent::BeginPlay()
@@ -977,14 +938,8 @@ void USkeletalMeshComponent::PopulatePhysicsAssetFromSkeleton(UPhysicsAsset* Phy
         NewBodySetup->LinearDamping = 0.05f;
         NewBodySetup->AngularDamping = 0.05f;
 
-        FKSphylElem CapsuleElem;
-        CapsuleElem.Center = FVector::ZeroVector;
-        CapsuleElem.Radius = CurrentRagdollBone.halfSize.x;
-        CapsuleElem.Length = CurrentRagdollBone.halfSize.y * 2.0f;
+        CalculateElement(NewBodySetup, BoneIndex);
 
-        CapsuleElem.Rotation = FRotator::ZeroRotator;
-
-        NewBodySetup->AggGeom.SphylElems.Add(CapsuleElem);
         PhysicsAssetToPopulate->BodySetup.Add(NewBodySetup);
     }
 
@@ -1050,7 +1005,8 @@ void USkeletalMeshComponent::CreateRagDollFromPhysicsAsset()
             int32 BoneIdx = SkeletalMeshAsset->GetSkeleton()->FindBoneIndex(Setup->BoneName);
             if (BoneIdx != INDEX_NONE)
             {
-                BoneWorldTransform = GetComponentTransform() * SkeletalMeshAsset->GetSkeleton()->GetReferenceSkeleton().GetRawRefBonePose()[BoneIdx];
+                //BoneWorldTransform = GetComponentTransform() * SkeletalMeshAsset->GetSkeleton()->GetReferenceSkeleton().GetRawRefBonePose()[BoneIdx];
+                BoneWorldTransform = GetSocketTransform(Setup->BoneName);
             }
             else
             {
@@ -1088,66 +1044,85 @@ void USkeletalMeshComponent::CreateRagDollFromPhysicsAsset()
         }
     }
 }
-
 void USkeletalMeshComponent::CalculateElement(UBodySetup* InBodySetup, int32 BoneIndex)
 {
-    FKSphylElem CapsuleElem;
-    CapsuleElem.Center = FVector(RagdollBones[BoneIndex].offset.x, RagdollBones[BoneIndex].offset.y, RagdollBones[BoneIndex].offset.z);
-    
-    float EstimatedBoneLength = -1.0f;
-    FVector ChildDirection = FVector::ForwardVector; // 기본 방향 (예: X축)
+    if (!InBodySetup)
+    {
+        // UE_LOG(LogTemp, Error, TEXT("CalculateElement: InBodySetup is null for BoneIndex %d"), BoneIndex);
+        return;
+    }
+    if (BoneIndex < 0 || BoneIndex >= RagdollBones.Num())
+    {
+        // UE_LOG(LogTemp, Error, TEXT("CalculateElement: Invalid BoneIndex %d. RagdollBones.Num() is %d"), BoneIndex, RagdollBones.Num());
+        return;
+    }
 
+    FKSphylElem CapsuleElem;
+
+    // 1. 고정된 반지름 설정
+    const float FixedRadius = 0.9f;
+    CapsuleElem.Radius = FixedRadius;
+
+    // 2. 캡슐 길이(원통 부분) 계산: 현재 본에서 자식 본까지의 거리
+    float CalculatedCylinderLength = 0.0f;
+    FVector BoneDirection = FVector::XAxisVector; // 기본 방향 (캡슐의 길이 방향 축)
+    FVector ChildLocalPos = FVector::XAxisVector;
+    bool bHasChild = false;
     for (int32 ChildSearchIdx = 0; ChildSearchIdx < RagdollBones.Num(); ++ChildSearchIdx)
     {
-        
+        // RagdollBones[ChildSearchIdx].parentIndex가 현재 BoneIndex와 같은 자식 본을 찾음
         if (RagdollBones[ChildSearchIdx].parentIndex == BoneIndex)
         {
-            FVector ChildLocalPos = FVector(RagdollBones[ChildSearchIdx].offset.x, RagdollBones[ChildSearchIdx].offset.y, RagdollBones[ChildSearchIdx].offset.z);
-            EstimatedBoneLength = ChildLocalPos.Size();
-            if (EstimatedBoneLength > KINDA_SMALL_NUMBER)
+            // 자식 본의 부모 기준 오프셋 벡터 (RagdollBones[ChildSearchIdx].offset은 부모(현재 BoneIndex) 기준 자식의 로컬 위치)
+            ChildLocalPos = FVector(RagdollBones[ChildSearchIdx].offset.x,
+                RagdollBones[ChildSearchIdx].offset.y,
+                RagdollBones[ChildSearchIdx].offset.z);
+
+            CalculatedCylinderLength = ChildLocalPos.Size()*0.8f; // 자식까지의 거리를 원통 길이로 사용
+
+            if (CalculatedCylinderLength > KINDA_SMALL_NUMBER)
             {
-                ChildDirection = ChildLocalPos.GetSafeNormal();
+                BoneDirection = ChildLocalPos.GetSafeNormal(); // 본의 방향 설정
             }
-            break;
+            else // 자식과의 거리가 매우 짧은 경우
+            {
+                CalculatedCylinderLength = MinCylinderLength; // 최소 길이 사용
+                // BoneDirection은 기본값(XAxisVector) 유지 또는 다른 방식 사용
+            }
+            bHasChild = true;
+            break; // 첫 번째 자식만 사용하여 길이와 방향 결정
         }
     }
 
-    if (EstimatedBoneLength <= KINDA_SMALL_NUMBER)
+    if (!bHasChild)
     {
-        EstimatedBoneLength = DefaultBoneLength;
+        CalculatedCylinderLength = MinCylinderLength; 
     }
-
-    CalculatedRadius = FMath::Max(MinRadius, EstimatedBoneLength * 0.25f);
-
-    CalculatedCylinderLength = EstimatedBoneLength - (2.0f * CalculatedRadius);
 
     if (CalculatedCylinderLength < MinCylinderLength)
     {
-        CalculatedRadius = FMath::Max(MinRadius, (EstimatedBoneLength - MinCylinderLength) / 2.0f);
-        CalculatedCylinderLength = FMath::Max(MinCylinderLength, EstimatedBoneLength - (2.0f * CalculatedRadius));
-
-        if (CalculatedCylinderLength < MinCylinderLength || CalculatedRadius < MinRadius)
-        {
-            CalculatedRadius = MinRadius;
-            CalculatedCylinderLength = MinCylinderLength;
-        }
+        CalculatedCylinderLength = MinCylinderLength;
     }
 
-    CapsuleElem.Radius = FMath::Clamp(CalculatedRadius, MinRadius, MaxRadius);
     CapsuleElem.Length = CalculatedCylinderLength;
 
-    if (ChildDirection.IsNearlyZero() || ChildDirection.Equals(FVector::ForwardVector))
+    CapsuleElem.Center = ChildLocalPos / 2;
+
+    if (BoneDirection.IsNearlyZero() || BoneDirection.Equals(FVector::XAxisVector))
     {
         CapsuleElem.Rotation = FRotator::ZeroRotator;
     }
     else
     {
-        FQuat RotQuat = FQuat::FindBetween(FVector::ForwardVector, ChildDirection);
+        FQuat RotQuat = FQuat::FindBetween(FVector::XAxisVector, BoneDirection);
         CapsuleElem.Rotation = RotQuat.Rotator();
     }
 
+    if (BoneIndex == 0) return;
     InBodySetup->AggGeom.SphylElems.Add(CapsuleElem);
+
 }
+
 
 PxTransform USkeletalMeshComponent::ToPxTransform(const FTransform& UnrealTransform)
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.h
@@ -8,7 +8,7 @@
 
 #include "PxPhysicsAPI.h"
 
-struct UConstraintInstance;
+struct FConstraintInstance;
 class UAnimSequence;
 class USkeletalMesh;
 struct FAnimNotifyEvent;
@@ -143,7 +143,7 @@ public:
     TArray<FBodyInstance*> Bodies;
 
     /** Array of FConstraintInstance structs, storing per-instance state about each constraint. */
-    TArray<UConstraintInstance*> Constraints;
+    TArray<FConstraintInstance*> Constraints;
 
     // 물리 상태 생성/파괴
     //virtual bool ShouldCreatePhysicsState() const;
@@ -196,7 +196,7 @@ public:
     bool IsRagDollSimulating() const { return bRagDollSimulating; }
 
     void InitializeRagDoll(const FReferenceSkeleton& InRefSkeleton);
-    void CreateRagDoll(const physx::PxVec3& WorldRoot);
+    //void CreateRagDoll(const physx::PxVec3& WorldRoot);
     void DestroyRagDoll();
 
     void UpdateRagdoll();
@@ -207,4 +207,17 @@ protected:
 
     void PopulatePhysicsAssetFromSkeleton(UPhysicsAsset* PhysicsAssetToPopulate, const FReferenceSkeleton& InRefSkeleton);
     void CreateRagDollFromPhysicsAsset();
+
+private:
+    const float DefaultBodyMass = 0.05f;
+    const float MinRadius = 0.1f;                     // 캡슐의 최소 반지름
+    const float MaxRadius = 3.0f;                     // 캡슐의 최대 반지름
+    const float DefaultRadius = 0.5f;                 // 기본 반지름
+    const float MinCylinderLength = 0.01f;             // 캡슐의 원통 부분 최소 길이
+    const float DefaultBoneLength = 2.0f;            // 자식이 없거나 길이가 매우 짧은 본의 기본 길이
+    float CalculatedRadius = 0.5f; //DefaultRadius
+    float CalculatedCylinderLength = 2.f; // 원통 부분의 길이 (DefaultBoneLength)
+
+    void CalculateElement(UBodySetup* InBodySetup, const FReferenceSkeleton& InRefSkeleton, int32 BoneIndex);
+
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.h
@@ -196,7 +196,6 @@ public:
     bool IsRagDollSimulating() const { return bRagDollSimulating; }
 
     void InitializeRagDoll(const FReferenceSkeleton& InRefSkeleton);
-    //void CreateRagDoll(const physx::PxVec3& WorldRoot);
     void DestroyRagDoll();
 
     void UpdateRagdoll();
@@ -218,6 +217,8 @@ private:
     float CalculatedRadius = 0.5f; //DefaultRadius
     float CalculatedCylinderLength = 2.f; // 원통 부분의 길이 (DefaultBoneLength)
 
-    void CalculateElement(UBodySetup* InBodySetup, const FReferenceSkeleton& InRefSkeleton, int32 BoneIndex);
+    void CalculateElement(UBodySetup* InBodySetup, int32 BoneIndex);
+
+    physx::PxTransform ToPxTransform(const FTransform& UnrealTransform);
 
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SkeletalMeshComponent.h
@@ -198,8 +198,6 @@ public:
     void InitializeRagDoll(const FReferenceSkeleton& InRefSkeleton);
     void DestroyRagDoll();
 
-    void UpdateRagdoll();
-
 protected:
     virtual void BeginPlay() override;
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
@@ -209,13 +207,11 @@ protected:
 
 private:
     const float DefaultBodyMass = 0.05f;
-    const float MinRadius = 0.1f;                     // 캡슐의 최소 반지름
-    const float MaxRadius = 3.0f;                     // 캡슐의 최대 반지름
-    const float DefaultRadius = 0.5f;                 // 기본 반지름
-    const float MinCylinderLength = 0.01f;             // 캡슐의 원통 부분 최소 길이
-    const float DefaultBoneLength = 2.0f;            // 자식이 없거나 길이가 매우 짧은 본의 기본 길이
-    float CalculatedRadius = 0.5f; //DefaultRadius
-    float CalculatedCylinderLength = 2.f; // 원통 부분의 길이 (DefaultBoneLength)
+    const float DefaultRadius = 2.f;                 // 기본 반지름
+    const float MinCylinderLength = 0.1f;             // 캡슐의 원통 부분 최소 길이
+    const float DefaultBoneLength = 20.0f;            // 자식이 없거나 길이가 매우 짧은 본의 기본 길이
+    float CalculatedRadius = 5.f; //DefaultRadius
+    float CalculatedCylinderLength = 20.f; // 원통 부분의 길이 (DefaultBoneLength)
 
     void CalculateElement(UBodySetup* InBodySetup, int32 BoneIndex);
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
@@ -47,7 +47,7 @@ void FBodyInstance::CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRi
     {
         if (PxShape* Shape = CreateShapeFromSphyl(SphylElem, *GMaterial))
         {
-            Shape->setContactOffset(0.02f);
+            Shape->setContactOffset(1.0f);
             Shape->setRestOffset(-0.1f);
 
             OutActor->attachShape(*Shape);
@@ -230,17 +230,19 @@ void FBodyInstance::InitBody(UPrimitiveComponent* InOwnerComponent, const UBodyS
                 MassToUse = InBodySetup->Mass;
             }
         }
-
         if (MassToUse > 0.0f)
         {
             PxRigidBodyExt::setMassAndUpdateInertia(*DynActor, MassToUse);
         }
-        DynActor->setRigidBodyFlag(PxRigidBodyFlag::eENABLE_CCD, true); // 코스트가 높음.
-        DynActor->setMaxDepenetrationVelocity(5.0f);
+        DynActor->setRigidBodyFlag(PxRigidBodyFlag::eENABLE_CCD, false); // 코스트가 높음.
+        DynActor->setMaxDepenetrationVelocity(8.0f);
         DynActor->setLinearDamping(InBodySetup->LinearDamping);
         DynActor->setAngularDamping(InBodySetup->AngularDamping);
         DynActor->setMaxLinearVelocity(30.f);
         DynActor->setMaxAngularVelocity(30.f);
+        DynActor->setSolverIterationCounts(12, 1);
+        SetLinearVelocity(FVector(0, 0, 0), false);
+        SetAngularVelocity(FVector(0, 0, 0), false);
     }
 
     GScene->addActor(*RigidActor);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.cpp
@@ -1,11 +1,11 @@
-﻿// ReSharper disable CppMemberFunctionMayBeConst
+// ReSharper disable CppMemberFunctionMayBeConst
 // ReSharper disable CppClangTidyCppcoreguidelinesProTypeStaticCastDowncast
 #include "BodyInstance.h"
 
 #include "BodySetup.h"
-#include "PxPhysicsAPI.h"
 #include "Components/PrimitiveComponent.h"
 #include "extensions/PxRigidBodyExt.h"
+
 
 using namespace physx;
 
@@ -15,46 +15,8 @@ extern PxDefaultCpuDispatcher* GDispatcher;
 extern PxScene* GScene;
 extern PxMaterial* GMaterial;
 
-struct FKSphereElem;
-struct FKBoxElem;
-struct FKSphylElem;
-struct FKConvexElem;
 
-
-struct FBodyInstance::FBodyInstancePImpl
-{
-    PxRigidActor* RigidActor;
-    void* UserData;
-
-    // 현재 물리 시뮬레이션 여부
-    bool bIsSimulatingPhysics;
-
-    FBodyInstancePImpl()
-        : RigidActor(nullptr)
-        , UserData(nullptr)
-        , bIsSimulatingPhysics(false)
-    {
-    }
-
-    ~FBodyInstancePImpl()
-    {
-        if (RigidActor)
-        {
-            RigidActor->release();
-            RigidActor = nullptr;
-        }
-    }
-
-    // UBodySetup의 FKAggregateGeom 정보를 바탕으로 PxShape들을 생성하고 PxRigidActor에 붙입니다.
-    void CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRigidActor* OutActor);
-
-    PxShape* CreateShapeFromSphere(const FKSphereElem& SphereElem, const PxMaterial& Material) const;
-    PxShape* CreateShapeFromBox(const FKBoxElem& BoxElem, const PxMaterial& Material) const;
-    PxShape* CreateShapeFromSphyl(const FKSphylElem& SphylElem, const PxMaterial& Material) const;
-    PxShape* CreateShapeFromConvex(const FKConvexElem& ConvexElem, const PxMaterial& Material) const;
-};
-
-void FBodyInstance::FBodyInstancePImpl::CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRigidActor* OutActor)
+void FBodyInstance::CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, PxRigidActor* OutActor)
 {
     if (!(BodySetupRef && RigidActor && GMaterial))
     {
@@ -100,7 +62,7 @@ void FBodyInstance::FBodyInstancePImpl::CreateShapesFromAggGeom(const UBodySetup
     }
 }
 
-PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromSphere(const FKSphereElem& SphereElem, const PxMaterial& Material) const
+PxShape* FBodyInstance::CreateShapeFromSphere(const FKSphereElem& SphereElem, const PxMaterial& Material) const
 {
     PxShape* Shape = GPhysics->createShape(
         PxSphereGeometry(SphereElem.Radius), Material, true, PxShapeFlag::eSIMULATION_SHAPE | PxShapeFlag::eSCENE_QUERY_SHAPE
@@ -115,7 +77,7 @@ PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromSphere(const FKSphere
     return Shape;
 }
 
-PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromBox(const FKBoxElem& BoxElem, const PxMaterial& Material) const
+PxShape* FBodyInstance::CreateShapeFromBox(const FKBoxElem& BoxElem, const PxMaterial& Material) const
 {
     PxShape* Shape = GPhysics->createShape(
         PxBoxGeometry(BoxElem.X, BoxElem.Y, BoxElem.Z), // 박스 지오메트리 (Half-Extents)
@@ -137,7 +99,7 @@ PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromBox(const FKBoxElem& 
     return Shape;
 }
 
-PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromSphyl(const FKSphylElem& SphylElem, const PxMaterial& Material) const
+PxShape* FBodyInstance::CreateShapeFromSphyl(const FKSphylElem& SphylElem, const PxMaterial& Material) const
 {
     PxShape* Shape = GPhysics->createShape(
         PxCapsuleGeometry(SphylElem.Radius, SphylElem.Length / 2.0f), // 캡슐 지오메트리
@@ -162,64 +124,59 @@ PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromSphyl(const FKSphylEl
     return Shape;
 }
 
-PxShape* FBodyInstance::FBodyInstancePImpl::CreateShapeFromConvex(const FKConvexElem& ConvexElem, const PxMaterial& Material) const
+PxShape* FBodyInstance::CreateShapeFromConvex(const FKConvexElem& ConvexElem, const PxMaterial& Material) const
 {
     return nullptr;
 }
 
 FBodyInstance::FBodyInstance()
     : OwnerComponent(nullptr)
-    , PImpl(std::make_unique<FBodyInstancePImpl>())
+    , RigidActor(nullptr)
+    , UserData(nullptr)
+    , bIsSimulatingPhysics(false)
 {
 }
 
 FBodyInstance::~FBodyInstance()
 {
     TermBody();
-    PImpl.reset();
 }
 
 FBodyInstance::FBodyInstance(FBodyInstance&& Other) noexcept
     : OwnerComponent(Other.OwnerComponent)
-    , PImpl(std::move(Other.PImpl))
 {
     Other.OwnerComponent = nullptr;
-    Other.PImpl = nullptr;
 }
 
 FBodyInstance& FBodyInstance::operator=(FBodyInstance&& Other) noexcept
 {
     if (this != &Other)
     {
-        PImpl = std::move(Other.PImpl);
         OwnerComponent = Other.OwnerComponent;
 
-        Other.PImpl = nullptr;
         Other.OwnerComponent = nullptr;
     }
     return *this;
 }
 
-void FBodyInstance::InitBody(
-    UPrimitiveComponent* InOwnerComponent, const UBodySetup* InBodySetup, const FTransform& InTransform, bool bInSimulatePhysics
-)
+void FBodyInstance::InitBody(UPrimitiveComponent* InOwnerComponent, const UBodySetup* InBodySetup, const FTransform& InTransform, bool bInSimulatePhysics)
 {
-    if (!(PImpl && GPhysics && GScene && GMaterial && InBodySetup && InOwnerComponent))
+    if (!(GPhysics && GScene && GMaterial && InBodySetup && InOwnerComponent))
     {
         // UE_LOG: 필수 객체 없음
         return;
     }
 
     // 이미 초기화되었다면 기존 것 해제
-    if (PImpl->RigidActor)
+    if (RigidActor)
     {
         TermBody();
-        // PImpl은 유지하고 내부 RigidActor만 새로 만듦
-        PImpl->RigidActor = nullptr; // 명시적 초기화
+        // 은 유지하고 내부 RigidActor만 새로 만듦
+        RigidActor = nullptr; // 명시적 초기화
     }
 
     OwnerComponent = InOwnerComponent;
-    PImpl->bIsSimulatingPhysics = bInSimulatePhysics;
+    bIsSimulatingPhysics = bInSimulatePhysics;
 
     const FVector Location = InTransform.GetLocation();
     const FQuat Rotation = InTransform.GetRotation();
@@ -231,27 +188,27 @@ void FBodyInstance::InitBody(
         )
     );
 
-    if (PImpl->bIsSimulatingPhysics)
+    if (bIsSimulatingPhysics)
     {
-        PImpl->RigidActor = GPhysics->createRigidDynamic(PxPose);
+        RigidActor = GPhysics->createRigidDynamic(PxPose);
     }
     else
     {
-        PImpl->RigidActor = GPhysics->createRigidStatic(PxPose);
+        RigidActor = GPhysics->createRigidStatic(PxPose);
     }
 
-    if (!PImpl->RigidActor)
+    if (!RigidActor)
     {
         // UE_LOG: RigidActor 생성 실패
         return;
     }
 
     // userData에 FBodyInstance* this를 저장 (PhysX 콜백 등에서 다시 FBodyInstance를 얻기 위함)
-    PImpl->RigidActor->userData = this;
+    RigidActor->userData = this;
 
-    PImpl->CreateShapesFromAggGeom(InBodySetup, PImpl->RigidActor);
+    CreateShapesFromAggGeom(InBodySetup, RigidActor);
 
-    if (PImpl->bIsSimulatingPhysics && PImpl->RigidActor->is<PxRigidDynamic>())
+    if (bIsSimulatingPhysics && RigidActor->is<PxRigidDynamic>())
     {
         // TODO: BodySetupRef 또는 OwnerComponent에서 질량/관성 관련 데이터 가져오기
         constexpr float Mass = 10.0f; // TODO: 예시 질량
@@ -259,22 +216,22 @@ void FBodyInstance::InitBody(
         {
             /* Mass = BodySetupRef->Mass; */
         }
-        PxRigidBodyExt::updateMassAndInertia(*static_cast<PxRigidDynamic*>(PImpl->RigidActor), Mass);
+        PxRigidBodyExt::updateMassAndInertia(*static_cast<PxRigidDynamic*>(RigidActor), Mass);
     }
 
-    GScene->addActor(*(PImpl->RigidActor));
+    GScene->addActor(*RigidActor);
 }
 
 void FBodyInstance::TermBody()
 {
-    if (PImpl && PImpl->RigidActor)
+    if (RigidActor)
     {
         if (GScene)
         {
-            GScene->removeActor(*(PImpl->RigidActor));
+            GScene->removeActor(*RigidActor);
         }
-        PImpl->RigidActor->release();
-        PImpl->RigidActor = nullptr;
+        RigidActor->release();
+        RigidActor = nullptr;
     }
     // OwnerComponent는 TermBody에서 null로 만들지 않음. InitBody에서 새로 설정.
     // 또는 FBodyInstance 소멸 시 OwnerComponent = nullptr; 처리.
@@ -282,11 +239,11 @@ void FBodyInstance::TermBody()
 
 void FBodyInstance::SyncPhysXToComponent()
 {
-    if (PImpl && PImpl->RigidActor && OwnerComponent && PImpl->bIsSimulatingPhysics) // 물리 시뮬레이션 중일 때만 동기화
+    if (RigidActor && OwnerComponent && bIsSimulatingPhysics) // 물리 시뮬레이션 중일 때만 동기화
     {
         PxSceneReadLock ScopedReadLock{*GScene};
 
-        const PxTransform PxPose = PImpl->RigidActor->getGlobalPose();
+        const PxTransform PxPose = RigidActor->getGlobalPose();
         const FVector NewLocation(PxPose.p.x, PxPose.p.y, PxPose.p.z);
         const FQuat NewRotation(PxPose.q.x, PxPose.q.y, PxPose.q.z, PxPose.q.w);
 
@@ -296,7 +253,7 @@ void FBodyInstance::SyncPhysXToComponent()
 
 void FBodyInstance::SyncComponentToPhysX()
 {
-    if (PImpl && PImpl->RigidActor && OwnerComponent && PImpl->bIsSimulatingPhysics)
+    if (RigidActor && OwnerComponent && bIsSimulatingPhysics)
     {
         PxSceneWriteLock ScopedWriteLock{*GScene};
 
@@ -309,20 +266,20 @@ void FBodyInstance::SyncComponentToPhysX()
             PxQuat(NewRotation.X, NewRotation.Y, NewRotation.Z, NewRotation.W)
         };
 
-        PImpl->RigidActor->setGlobalPose(PxNewPose);
+        RigidActor->setGlobalPose(PxNewPose);
     }
 }
 
 bool FBodyInstance::IsValidBodyInstance() const
 {
-    return PImpl && PImpl->RigidActor;
+    return RigidActor;
 }
 
 void FBodyInstance::AddForce(const FVector& Force, bool bAccelChange)
 {
-    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    if (RigidActor && RigidActor->is<PxRigidBody>())
     {
-        PxRigidBody* RigidBody = static_cast<PxRigidBody*>(PImpl->RigidActor);
+        PxRigidBody* RigidBody = static_cast<PxRigidBody*>(RigidActor);
         const PxVec3 PxForce(Force.X, Force.Y, Force.Z);
         const PxForceMode::Enum Mode = bAccelChange ? PxForceMode::eACCELERATION : PxForceMode::eFORCE;
         RigidBody->addForce(PxForce, Mode);
@@ -331,9 +288,9 @@ void FBodyInstance::AddForce(const FVector& Force, bool bAccelChange)
 
 void FBodyInstance::SetLinearVelocity(const FVector& NewVel, bool bAddToCurrent)
 {
-    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    if (RigidActor && RigidActor->is<PxRigidBody>())
     {
-        PxRigidBody* RigidBody = static_cast<PxRigidBody*>(PImpl->RigidActor);
+        PxRigidBody* RigidBody = static_cast<PxRigidBody*>(RigidActor);
         PxVec3 PxNewVel(NewVel.X, NewVel.Y, NewVel.Z);
         if (bAddToCurrent)
         {
@@ -345,9 +302,9 @@ void FBodyInstance::SetLinearVelocity(const FVector& NewVel, bool bAddToCurrent)
 
 FVector FBodyInstance::GetLinearVelocity() const
 {
-    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    if (RigidActor && RigidActor->is<PxRigidBody>())
     {
-        const PxVec3 PxVel = static_cast<PxRigidBody*>(PImpl->RigidActor)->getLinearVelocity();
+        const PxVec3 PxVel = static_cast<PxRigidBody*>(RigidActor)->getLinearVelocity();
         return FVector{PxVel.x, PxVel.y, PxVel.z};
     }
     return FVector::ZeroVector;
@@ -355,9 +312,9 @@ FVector FBodyInstance::GetLinearVelocity() const
 
 void FBodyInstance::SetAngularVelocity(const FVector& NewAngVel, bool bAddToCurrent)
 {
-    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    if (RigidActor && RigidActor->is<PxRigidBody>())
     {
-        PxRigidBody* RigidBody = static_cast<PxRigidBody*>(PImpl->RigidActor);
+        PxRigidBody* RigidBody = static_cast<PxRigidBody*>(RigidActor);
         PxVec3 PxNewAngVel(NewAngVel.X, NewAngVel.Y, NewAngVel.Z); // 엔진 좌표계와 PhysX 좌표계가 다르면 변환 필요
         if (bAddToCurrent)
         {
@@ -369,9 +326,9 @@ void FBodyInstance::SetAngularVelocity(const FVector& NewAngVel, bool bAddToCurr
 
 FVector FBodyInstance::GetAngularVelocity() const
 {
-    if (PImpl && PImpl->RigidActor && PImpl->RigidActor->is<PxRigidBody>())
+    if (RigidActor && RigidActor->is<PxRigidBody>())
     {
-        const PxVec3 PxAngVel = static_cast<PxRigidBody*>(PImpl->RigidActor)->getAngularVelocity();
+        const PxVec3 PxAngVel = static_cast<PxRigidBody*>(RigidActor)->getAngularVelocity();
         return FVector{PxAngVel.x, PxAngVel.y, PxAngVel.z}; // 좌표계 변환 필요할 수 있음
     }
     return FVector::ZeroVector;
@@ -379,9 +336,9 @@ FVector FBodyInstance::GetAngularVelocity() const
 
 FTransform FBodyInstance::GetWorldTransform() const
 {
-    if (PImpl && PImpl->RigidActor)
+    if (RigidActor)
     {
-        const PxTransform PxPose = PImpl->RigidActor->getGlobalPose();
+        const PxTransform PxPose = RigidActor->getGlobalPose();
         return FTransform{
             FQuat(PxPose.q.x, PxPose.q.y, PxPose.q.z, PxPose.q.w),
             FVector(PxPose.p.x, PxPose.p.y, PxPose.p.z)
@@ -392,25 +349,25 @@ FTransform FBodyInstance::GetWorldTransform() const
 
 void FBodyInstance::SetWorldTransform(const FTransform& NewTransform, bool bTeleportPhysics)
 {
-    if (PImpl && PImpl->RigidActor)
+    if (RigidActor)
     {
         const PxTransform PxNewPose(
             PxVec3(NewTransform.GetLocation().X, NewTransform.GetLocation().Y, NewTransform.GetLocation().Z),
             PxQuat(NewTransform.GetRotation().X, NewTransform.GetRotation().Y, NewTransform.GetRotation().Z, NewTransform.GetRotation().W)
         );
 
-        if (PImpl->RigidActor->is<PxRigidDynamic>())
+        if (RigidActor->is<PxRigidDynamic>())
         {
             // bTeleportPhysics 플래그는 PhysX에서 직접적으로 지원하는 것은 아니지만,
             // Kinematic Actor의 경우 setKinematicTarget, Dynamic Actor의 경우 setGlobalPose 후 wakeUp 등을 의미할 수 있음.
             // 간단히 setGlobalPose 사용. Kinematic인 경우 추가 처리가 필요할 수 있음.
-            PImpl->RigidActor->setGlobalPose(PxNewPose);
+            RigidActor->setGlobalPose(PxNewPose);
             if (!bTeleportPhysics) // 순간이동이 아니면 깨움 (물리가 즉시 반응하도록)
             {
-                static_cast<PxRigidDynamic*>(PImpl->RigidActor)->wakeUp();
+                static_cast<PxRigidDynamic*>(RigidActor)->wakeUp();
             }
         }
-        else if (PImpl->RigidActor->is<PxRigidStatic>())
+        else if (RigidActor->is<PxRigidStatic>())
         {
             // Static Actor는 런타임에 Transform 변경 불가 (만약 필요하면 재생성해야 함)
             // UE_LOG: Static Actor의 Transform은 변경할 수 없습니다.
@@ -420,21 +377,21 @@ void FBodyInstance::SetWorldTransform(const FTransform& NewTransform, bool bTele
 
 void FBodyInstance::SetSimulatePhysics(bool bSimulate)
 {
-    if (PImpl && PImpl->bIsSimulatingPhysics != bSimulate)
+    if (bIsSimulatingPhysics != bSimulate)
     {
-        PImpl->bIsSimulatingPhysics = bSimulate;
-        if (PImpl->RigidActor)
+        bIsSimulatingPhysics = bSimulate;
+        if (RigidActor)
         {
             // TODO: 실제로는 Actor Type을 Dynamic <-> Static으로 변경하거나,
             // Dynamic Actor의 플래그를 변경하는 복잡한 과정이 필요할 수 있습니다.
             // (예: PxRigidBodyFlag::eKINEMATIC 설정/해제)
             // 여기서는 단순 플래그만 변경하고, InitBody 시점에 실제 Actor Type이 결정된다고 가정합니다.
             // 혹은, 해당 플래그에 따라 Actor를 재생성해야 할 수도 있습니다.
-            if (PImpl->RigidActor->is<PxRigidDynamic>())
+            if (RigidActor->is<PxRigidDynamic>())
             {
                 // 물리 시뮬레이션을 끄면 Kinematic으로 만들거나 Gravity를 끌 수 있음
                 // 여기서는 간단히 Actor flag를 조절한다고 가정 (예시)
-                // static_cast<physx::PxRigidDynamic*>(PImpl->RigidActor)->setRigidBodyFlag(physx::PxRigidBodyFlag::eKINEMATIC, !bSimulate);
+                // static_cast<physx::PxRigidDynamic*>(->RigidActor)->setRigidBodyFlag(physx::PxRigidBodyFlag::eKINEMATIC, !bSimulate);
             }
             // UE_LOG: SetSimulatePhysics 호출됨, 현재 상태: %s", bSimulate ? "On" : "Off");
         }
@@ -443,19 +400,16 @@ void FBodyInstance::SetSimulatePhysics(bool bSimulate)
 
 bool FBodyInstance::IsSimulatingPhysics() const
 {
-    return PImpl && PImpl->bIsSimulatingPhysics;
+    return bIsSimulatingPhysics;
 }
 
 
 void FBodyInstance::SetUserData(void* InUserData)
 {
-    if (PImpl)
-    {
-        PImpl->UserData = InUserData;
-    }
+    UserData = InUserData;
 }
 
 void* FBodyInstance::GetUserData() const
 {
-    return PImpl ? PImpl->UserData : nullptr;
+    return UserData;
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.h
@@ -1,5 +1,3 @@
-// BodyInstance.h
-
 #pragma once
 #include "BodyInstanceCore.h"
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.h
@@ -1,9 +1,17 @@
-﻿#pragma once
+// BodyInstance.h
+
+#pragma once
 #include "BodyInstanceCore.h"
+
+#include "PxPhysicsAPI.h" 
 
 class UBodySetup;
 class UPrimitiveComponent;
 
+struct FKSphereElem; 
+struct FKBoxElem;
+struct FKSphylElem;
+struct FKConvexElem;
 
 struct FBodyInstance : FBodyInstanceCore
 {
@@ -42,9 +50,18 @@ public:
     void SetUserData(void* InUserData);
     void* GetUserData() const;
 
+    physx::PxRigidActor* RigidActor; 
+    void* UserData;
+
+    bool bIsSimulatingPhysics;
+
+    void CreateShapesFromAggGeom(const UBodySetup* BodySetupRef, physx::PxRigidActor* OutActor); 
+
+    physx::PxShape* CreateShapeFromSphere(const FKSphereElem& SphereElem, const physx::PxMaterial& Material) const; 
+    physx::PxShape* CreateShapeFromBox(const FKBoxElem& BoxElem, const physx::PxMaterial& Material) const; 
+    physx::PxShape* CreateShapeFromSphyl(const FKSphylElem& SphylElem, const physx::PxMaterial& Material) const;
+    physx::PxShape* CreateShapeFromConvex(const FKConvexElem& ConvexElem, const physx::PxMaterial& Material) const; 
+
 private:
     TWeakObjectPtr<UPrimitiveComponent> OwnerComponent;
-
-    struct FBodyInstancePImpl;
-    std::unique_ptr<FBodyInstancePImpl> PImpl;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstance.h
@@ -45,6 +45,8 @@ public:
     void SetSimulatePhysics(bool bSimulate);
     bool IsSimulatingPhysics() const;
 
+    physx::PxRigidActor* RigidActor;
+
 private:
     TWeakObjectPtr<UPrimitiveComponent> OwnerComponent;
 
@@ -57,7 +59,6 @@ private:
     physx::PxShape* CreateShapeFromSphyl(const FKSphylElem& SphylElem, const physx::PxMaterial& Material) const;
     physx::PxShape* CreateShapeFromConvex(const FKConvexElem& ConvexElem, const physx::PxMaterial& Material) const;
 
-    physx::PxRigidActor* RigidActor;
 
     // 현재 물리 시뮬레이션 여부
     bool bIsSimulatingPhysics;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstanceCore.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodyInstanceCore.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "UObject/ObjectMacros.h"
 
 class UBodySetupCore;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
@@ -16,4 +16,15 @@ public:
         EditAnywhere, ({ .Category = "BodySetup", .DisplayName = "Primitives" }),
         FKAggregateGeom, AggGeom, ;
     )
+
+    UPROPERTY
+    (float, Mass)
+    UPROPERTY
+    (bool, bOverrideMass)
+    UPROPERTY
+    (float, Density)
+    UPROPERTY
+    (float, LinearDamping)
+    UPROPERTY
+    (float, AngularDamping)
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetup.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "AggregateGeom.h"
 #include "BodySetupCore.h"
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetupCore.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/BodySetupCore.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "UObject/Object.h"
 #include "UObject/ObjectMacros.h"
 
@@ -9,6 +9,10 @@ class UBodySetupCore : public UObject
 
 public:
     UBodySetupCore() = default;
+    UBodySetupCore(const FName& InBoneName)
+        : BoneName(InBoneName)
+    { }
+
     virtual ~UBodySetupCore() override = default;
 
 public:

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
@@ -32,8 +32,6 @@ public:
     // TODO: Implements This
     void TermConstraint();
 
-    physx::PxTransform ToPxTransform(const FTransform& UnrealTransform);
-
     void InitConstraint(const UConstraintSetup* Setup, FBodyInstance* InBody1, FBodyInstance* InBody2, USkeletalMeshComponent* OwnerComp, bool bInSimulatePhysics);
 
     FBodyInstance* Body1 = nullptr;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
@@ -1,24 +1,26 @@
 #pragma once
 #include "UObject/ObjectMacros.h"
 
+#include "PxPhysicsAPI.h" 
 #include "PhysicsEngine/BodyInstance.h"
+#include "ConstraintInstanceCore.h"
 
 class USkeletalMeshComponent;
 class UPrimitiveComponent;
 class UConstraintSetup;
 
-class UConstraintInstance : public UConstraintSetup
+struct FConstraintInstance : FConstraintInstanceCore
 {
-    DECLARE_CLASS(UConstraintInstance, UConstraintSetup)
+    DECLARE_STRUCT(FConstraintInstance, FConstraintInstanceCore)
 
 public:
-    UConstraintInstance() = default;
-    virtual ~UConstraintInstance() override = default;
+    FConstraintInstance() = default;
+    virtual ~FConstraintInstance() override = default;
 
-    UConstraintInstance(const UConstraintInstance&) = default;
-    UConstraintInstance& operator=(const UConstraintInstance&) = default;
-    UConstraintInstance(UConstraintInstance&&) = default;
-    UConstraintInstance& operator=(UConstraintInstance&&) = default;
+    FConstraintInstance(const FConstraintInstance&) = default;
+    FConstraintInstance& operator=(const FConstraintInstance&) = default;
+    FConstraintInstance(FConstraintInstance&&) = default;
+    FConstraintInstance& operator=(FConstraintInstance&&) = default;
 
 public:
     UPROPERTY(
@@ -34,7 +36,6 @@ public:
 
     void InitConstraint(const UConstraintSetup* Setup, FBodyInstance* InBody1, FBodyInstance* InBody2, USkeletalMeshComponent* OwnerComp, bool bInSimulatePhysics);
 
-private:
     FBodyInstance* Body1 = nullptr;
     FBodyInstance* Body2 = nullptr;
     physx::PxJoint* Joint = nullptr;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.h
@@ -1,34 +1,24 @@
-﻿#pragma once
+#pragma once
 #include "UObject/ObjectMacros.h"
 
+#include "PhysicsEngine/BodyInstance.h"
 
-struct FConstraintInstanceBase
+class USkeletalMeshComponent;
+class UPrimitiveComponent;
+class UConstraintSetup;
+
+class UConstraintInstance : public UConstraintSetup
 {
-    DECLARE_STRUCT(FConstraintInstanceBase)
+    DECLARE_CLASS(UConstraintInstance, UConstraintSetup)
 
 public:
-    FConstraintInstanceBase() = default;
-    virtual ~FConstraintInstanceBase() = default;
+    UConstraintInstance() = default;
+    virtual ~UConstraintInstance() override = default;
 
-    FConstraintInstanceBase(const FConstraintInstanceBase&) = default;
-    FConstraintInstanceBase& operator=(const FConstraintInstanceBase&) = default;
-    FConstraintInstanceBase(FConstraintInstanceBase&&) = default;
-    FConstraintInstanceBase& operator=(FConstraintInstanceBase&&) = default;
-};
-
-
-struct FConstraintInstance : public FConstraintInstanceBase
-{
-    DECLARE_STRUCT(FConstraintInstance, FConstraintInstanceBase)
-
-public:
-    FConstraintInstance() = default;
-    virtual ~FConstraintInstance() override = default;
-
-    FConstraintInstance(const FConstraintInstance&) = default;
-    FConstraintInstance& operator=(const FConstraintInstance&) = default;
-    FConstraintInstance(FConstraintInstance&&) = default;
-    FConstraintInstance& operator=(FConstraintInstance&&) = default;
+    UConstraintInstance(const UConstraintInstance&) = default;
+    UConstraintInstance& operator=(const UConstraintInstance&) = default;
+    UConstraintInstance(UConstraintInstance&&) = default;
+    UConstraintInstance& operator=(UConstraintInstance&&) = default;
 
 public:
     UPROPERTY(
@@ -38,7 +28,15 @@ public:
 
 public:
     // TODO: Implements This
-    void TermConstraint()
-    {
-    }
+    void TermConstraint();
+
+    physx::PxTransform ToPxTransform(const FTransform& UnrealTransform);
+
+    void InitConstraint(const UConstraintSetup* Setup, FBodyInstance* InBody1, FBodyInstance* InBody2, USkeletalMeshComponent* OwnerComp, bool bInSimulatePhysics);
+
+private:
+    FBodyInstance* Body1 = nullptr;
+    FBodyInstance* Body2 = nullptr;
+    physx::PxJoint* Joint = nullptr;
+    bool bInitialized = false; 
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
@@ -67,9 +67,7 @@ void FPhysX::Initialize()
         PvdClient->setScenePvdFlag(PxPvdSceneFlag::eTRANSMIT_SCENEQUERIES, true);
     }
 #endif
-
     GMaterial = GPhysics->createMaterial(0.5f, 0.5f, 0.6f);
-
     // PhysX Cooking 라이브러리 초기화 (필요시)
     // PxInitExtensions(*GPhysics, pvd);
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
@@ -69,7 +69,7 @@ void FPhysX::Initialize()
 #endif
     GMaterial = GPhysics->createMaterial(0.5f, 0.5f, 0.6f);
     // PhysX Cooking 라이브러리 초기화 (필요시)
-    // PxInitExtensions(*GPhysics, pvd);
+    PxInitExtensions(*GPhysics, Pvd);
 }
 
 void FPhysX::Tick(float DeltaTime)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
@@ -1,4 +1,4 @@
-﻿#include "PhysX.h"
+#include "PhysX.h"
 #include "PxPhysicsAPI.h"
 
 using namespace physx;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysX/PhysX.cpp
@@ -51,6 +51,7 @@ void FPhysX::Initialize()
     SceneDesc.flags |= PxSceneFlag::eENABLE_ACTIVE_ACTORS;
     SceneDesc.flags |= PxSceneFlag::eENABLE_CCD;
     SceneDesc.flags |= PxSceneFlag::eENABLE_PCM;
+
     GScene = GPhysics->createScene(SceneDesc);
 
 #ifdef _DEBUG

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysicsAsset.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/PhysicsAsset.h
@@ -1,9 +1,9 @@
-﻿#pragma once
+#pragma once
 #include "UObject/Object.h"
 #include "UObject/ObjectMacros.h"
+#include "ConstraintSetup.h"
 
 class UBodySetup;
-
 
 class UPhysicsAsset : public UObject
 {
@@ -17,5 +17,10 @@ public:
     UPROPERTY(
         EditAnywhere | EditInline,
         TArray<UBodySetup*>, BodySetup, ;
+    )
+
+    UPROPERTY(
+        EditAnywhere | EditInline,
+        TArray<UConstraintSetup*>, ConstraintSetup, ;
     )
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/SphylElem.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/SphylElem.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "ShapeElem.h"
 #include "UObject/ObjectMacros.h"
 

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -135,6 +135,8 @@
     <Message Text="--- Copy Library Tasks Finished ---" Importance="high" />
   </Target>
   <ItemGroup>
+    <ClCompile Include="ConstraintInstance.cpp" />
+    <ClCompile Include="ConstraintSetupCore.cpp" />
     <ClCompile Include="Engine\Source\Contents\Actors\Fish.cpp" />
     <ClCompile Include="Engine\Source\Contents\Actors\GoalPlatformActor.cpp" />
     <ClCompile Include="Engine\Source\Contents\Actors\ItemActor.cpp" />
@@ -300,11 +302,11 @@
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocity.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityBase.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityOverLife.cpp" />
-    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstance.cpp"/>
-    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetup.cpp"/>
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstance.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetup.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetupCore.cpp" />
-    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysicsAsset.cpp"/>
-    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\PhysX.cpp"/>
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysicsAsset.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\PhysX.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\ParticleEmitterInstance.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\ParticleHelper.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Particles\ParticleSystemRender.cpp" />
@@ -374,6 +376,8 @@
     <ClCompile Include="SoundManager.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ConstraintSetup.h" />
+    <ClInclude Include="ConstraintSetupCore.h" />
     <ClInclude Include="Engine\Source\Contents\Actors\Fish.h" />
     <ClInclude Include="Engine\Source\Contents\Actors\GoalPlatformActor.h" />
     <ClInclude Include="Engine\Source\Contents\Actors\ItemActor.h" />
@@ -587,19 +591,19 @@
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocity.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityBase.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityOverLife.h" />
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\AggregateGeom.h"/>
-      <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstance.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstanceCore.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetup.h"/>
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\AggregateGeom.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstance.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstanceCore.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetup.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetupCore.h" />
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BoxElem.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ConstraintInstance.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ConvexElem.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysicsAsset.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\PhysX.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ShapeElem.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\SphereElem.h"/>
-    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\SphylElem.h"/>
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BoxElem.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ConstraintInstance.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ConvexElem.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysicsAsset.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\PhysX.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ShapeElem.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\SphereElem.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\SphylElem.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\ParticleEmitterInstance.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\ParticleHelper.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\ReferenceSkeleton.h" />
@@ -770,7 +774,7 @@
     <None Include="Shaders\SlateShader.hlsl" />
     <None Include="Shaders\StaticMeshVertexShader.hlsl" />
     <None Include="Shaders\TileLightCullingComputeShader.hlsl" />
-    <None Include="Shaders\UpSampleShader.hlsl"/>
+    <None Include="Shaders\UpSampleShader.hlsl" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -376,6 +376,7 @@
     <ClCompile Include="SoundManager.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ConstraintInstanceCore.h" />
     <ClInclude Include="ConstraintSetup.h" />
     <ClInclude Include="ConstraintSetupCore.h" />
     <ClInclude Include="Engine\Source\Contents\Actors\Fish.h" />

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj.filters
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj.filters
@@ -1812,6 +1812,7 @@
     <ClInclude Include="Engine\Source\Runtime\Renderer\PostProcess\PostProcessRenderPass.h" />
     <ClInclude Include="ConstraintSetup.h" />
     <ClInclude Include="ConstraintSetupCore.h" />
+    <ClInclude Include="ConstraintInstanceCore.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Shaders\CompositingShader.hlsl" />

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj.filters
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj.filters
@@ -1261,12 +1261,6 @@
     <ClInclude Include="Engine\Source\Runtime\Renderer\BillboardRenderPass.h">
       <Filter>Engine\Source\Runtime\Renderer</Filter>
     </ClInclude>
-    <ClCompile Include="Engine\Source\Runtime\Renderer\CameraEffectRenderPass.cpp">
-      <Filter>Engine\Source\Runtime\Renderer</Filter>
-    </ClCompile>
-    <ClInclude Include="Engine\Source\Runtime\Renderer\CameraEffectRenderPass.h">
-      <Filter>Engine\Source\Runtime\Renderer</Filter>
-    </ClInclude>
     <ClCompile Include="Engine\Source\Runtime\Renderer\CompositingPass.cpp">
       <Filter>Engine\Source\Runtime\Renderer</Filter>
     </ClCompile>
@@ -1291,12 +1285,6 @@
     <ClInclude Include="Engine\Source\Runtime\Renderer\EditorRenderPass.h">
       <Filter>Engine\Source\Runtime\Renderer</Filter>
     </ClInclude>
-    <ClCompile Include="Engine\Source\Runtime\Renderer\FogRenderPass.cpp">
-      <Filter>Engine\Source\Runtime\Renderer</Filter>
-    </ClCompile>
-    <ClInclude Include="Engine\Source\Runtime\Renderer\FogRenderPass.h">
-      <Filter>Engine\Source\Runtime\Renderer</Filter>
-    </ClInclude>
     <ClCompile Include="Engine\Source\Runtime\Renderer\GizmoRenderPass.cpp">
       <Filter>Engine\Source\Runtime\Renderer</Filter>
     </ClCompile>
@@ -1310,12 +1298,6 @@
       <Filter>Engine\Source\Runtime\Renderer</Filter>
     </ClCompile>
     <ClInclude Include="Engine\Source\Runtime\Renderer\LineRenderPass.h">
-      <Filter>Engine\Source\Runtime\Renderer</Filter>
-    </ClInclude>
-    <ClCompile Include="Engine\Source\Runtime\Renderer\PostProcessCompositingPass.cpp">
-      <Filter>Engine\Source\Runtime\Renderer</Filter>
-    </ClCompile>
-    <ClInclude Include="Engine\Source\Runtime\Renderer\PostProcessCompositingPass.h">
       <Filter>Engine\Source\Runtime\Renderer</Filter>
     </ClInclude>
     <ClCompile Include="Engine\Source\Runtime\Renderer\Renderer.cpp">
@@ -1694,6 +1676,18 @@
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityOverLife.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Acceleration\ParticleModuleAcceleration.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\Acceleration\ParticleModuleAccelerationBase.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstance.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetup.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetupCore.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysicsAsset.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\PhysX.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\PostProcess\CameraEffectRenderPass.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\PostProcess\DepthOfFieldRenderPass.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\PostProcess\FogRenderPass.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\PostProcess\PostProcessCompositingPass.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\PostProcess\PostProcessRenderPass.cpp" />
+    <ClCompile Include="ConstraintInstance.cpp" />
+    <ClCompile Include="ConstraintSetupCore.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="EngineSIU.natvis" />
@@ -1798,6 +1792,26 @@
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Velocity\ParticleModuleVelocityOverLife.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Acceleration\ParticleModuleAcceleration.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Acceleration\ParticleModuleAccelerationBase.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\AggregateGeom.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstance.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodyInstanceCore.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetup.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BodySetupCore.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\BoxElem.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ConstraintInstance.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ConvexElem.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysicsAsset.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\PhysX\PhysX.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\ShapeElem.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\SphereElem.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\PhysicsEngine\SphylElem.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\PostProcess\CameraEffectRenderPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\PostProcess\DepthOfFieldRenderPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\PostProcess\FogRenderPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\PostProcess\PostProcessCompositingPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\PostProcess\PostProcessRenderPass.h" />
+    <ClInclude Include="ConstraintSetup.h" />
+    <ClInclude Include="ConstraintSetupCore.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Shaders\CompositingShader.hlsl" />
@@ -1830,5 +1844,7 @@
     <None Include="Shaders\DepthCubeMapVS.hlsl" />
     <None Include="Shaders\DepthOnlyVS.hlsl" />
     <None Include="Shaders\PointLightCubemapGS.hlsl" />
+    <None Include="Shaders\DownSampleShader.hlsl" />
+    <None Include="Shaders\UpSampleShader.hlsl" />
   </ItemGroup>
 </Project>

--- a/EngineSIU/EngineSIU/Saved/AutoSaves.scene
+++ b/EngineSIU/EngineSIU/Saved/AutoSaves.scene
@@ -2,18 +2,18 @@
     "Actors": [
         {
             "ActorClass": "AActor",
-            "ActorID": "AActor_227",
-            "ActorLabel": "AActor227",
+            "ActorID": "AActor_155",
+            "ActorLabel": "OBJ_SKELETALMESH_155",
             "ActorTickInEditor": "true",
             "Components": [
                 {
                     "ComponentClass": "USceneComponent",
-                    "ComponentID": "USceneComponent_228",
+                    "ComponentID": "USceneComponent_156",
                     "Properties": {
-                        "AttachParentID": "USkeletalMeshComponent_229",
+                        "AttachParentID": "USkeletalMeshComponent_157",
                         "ComponentClass": "USceneComponent",
-                        "ComponentName": "USceneComponent_228",
-                        "ComponentOwner": "AActor_227",
+                        "ComponentName": "USceneComponent_156",
+                        "ComponentOwner": "AActor_155",
                         "ComponentOwnerClass": "AActor",
                         "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
                         "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
@@ -24,14 +24,14 @@
                 },
                 {
                     "ComponentClass": "USkeletalMeshComponent",
-                    "ComponentID": "USkeletalMeshComponent_229",
+                    "ComponentID": "USkeletalMeshComponent_157",
                     "Properties": {
                         "AABB_max": "X=17.174 Y=90.257 Z=180.888",
                         "AABB_min": "X=-14.896 Y=-90.257 Z=-0.035",
                         "AttachParentID": "nullptr",
                         "ComponentClass": "USkeletalMeshComponent",
-                        "ComponentName": "USkeletalMeshComponent_229",
-                        "ComponentOwner": "AActor_227",
+                        "ComponentName": "USkeletalMeshComponent_157",
+                        "ComponentOwner": "AActor_155",
                         "ComponentOwnerClass": "AActor",
                         "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
                         "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=-0.000",
@@ -42,119 +42,7 @@
                     }
                 }
             ],
-            "RootComponentID": "USkeletalMeshComponent_229"
-        },
-        {
-            "ActorClass": "APlayer",
-            "ActorID": "APlayer_297",
-            "ActorLabel": "OBJ_PLAYER_297",
-            "ActorTickInEditor": "false",
-            "Components": [
-                {
-                    "ComponentClass": "USceneComponent",
-                    "ComponentID": "USceneComponent_298",
-                    "Properties": {
-                        "AttachParentID": "nullptr",
-                        "ComponentClass": "USceneComponent",
-                        "ComponentName": "USceneComponent_298",
-                        "ComponentOwner": "APlayer_297",
-                        "ComponentOwnerClass": "APlayer",
-                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "bAutoActive": "true",
-                        "bIsActive": "true"
-                    }
-                }
-            ],
-            "RootComponentID": "USceneComponent_298"
-        },
-        {
-            "ActorClass": "APlayerController",
-            "ActorID": "APlayerController_299",
-            "ActorLabel": "OBJ_PLAYER_CONTROLLER_299",
-            "ActorTickInEditor": "false",
-            "Components": [
-                {
-                    "ComponentClass": "UInputComponent",
-                    "ComponentID": "UInputComponent_300",
-                    "Properties": {
-                        "ComponentClass": "UInputComponent",
-                        "ComponentName": "UInputComponent_300",
-                        "ComponentOwner": "APlayerController_299",
-                        "ComponentOwnerClass": "APlayerController",
-                        "bAutoActive": "true",
-                        "bIsActive": "true"
-                    }
-                },
-                {
-                    "ComponentClass": "USceneComponent",
-                    "ComponentID": "USceneComponent_303",
-                    "Properties": {
-                        "AttachParentID": "nullptr",
-                        "ComponentClass": "USceneComponent",
-                        "ComponentName": "USceneComponent_303",
-                        "ComponentOwner": "APlayerController_299",
-                        "ComponentOwnerClass": "APlayerController",
-                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "bAutoActive": "true",
-                        "bIsActive": "true"
-                    }
-                }
-            ],
-            "RootComponentID": "USceneComponent_303"
-        },
-        {
-            "ActorClass": "APlayerCameraManager",
-            "ActorID": "APlayerCameraManager_301",
-            "ActorLabel": "APlayerCameraManager301",
-            "ActorTickInEditor": "false",
-            "Components": [
-                {
-                    "ComponentClass": "USceneComponent",
-                    "ComponentID": "USceneComponent_302",
-                    "Properties": {
-                        "AttachParentID": "nullptr",
-                        "ComponentClass": "USceneComponent",
-                        "ComponentName": "USceneComponent_302",
-                        "ComponentOwner": "APlayerCameraManager_301",
-                        "ComponentOwnerClass": "APlayerCameraManager",
-                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "bAutoActive": "true",
-                        "bIsActive": "true"
-                    }
-                }
-            ],
-            "RootComponentID": "USceneComponent_302"
-        },
-        {
-            "ActorClass": "AGameMode",
-            "ActorID": "AGameMode_304",
-            "ActorLabel": "OBJ_GAMEMODE_304",
-            "ActorTickInEditor": "false",
-            "Components": [
-                {
-                    "ComponentClass": "USceneComponent",
-                    "ComponentID": "USceneComponent_305",
-                    "Properties": {
-                        "AttachParentID": "nullptr",
-                        "ComponentClass": "USceneComponent",
-                        "ComponentName": "USceneComponent_305",
-                        "ComponentOwner": "AGameMode_304",
-                        "ComponentOwnerClass": "AGameMode",
-                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "bAutoActive": "true",
-                        "bIsActive": "true"
-                    }
-                }
-            ],
-            "RootComponentID": "USceneComponent_305"
+            "RootComponentID": "USkeletalMeshComponent_157"
         }
     ],
     "NextUUID": 0,

--- a/EngineSIU/EngineSIU/Saved/AutoSaves.scene
+++ b/EngineSIU/EngineSIU/Saved/AutoSaves.scene
@@ -1,20 +1,20 @@
 {
     "Actors": [
         {
-            "ActorClass": "ASkeletalMeshActor",
-            "ActorID": "ASkeletalMeshActor_196",
-            "ActorLabel": "OBJ_SKELETALMESH_196",
+            "ActorClass": "AActor",
+            "ActorID": "AActor_227",
+            "ActorLabel": "AActor227",
             "ActorTickInEditor": "true",
             "Components": [
                 {
                     "ComponentClass": "USceneComponent",
-                    "ComponentID": "USceneComponent_197",
+                    "ComponentID": "USceneComponent_228",
                     "Properties": {
-                        "AttachParentID": "USkeletalMeshComponent_198",
+                        "AttachParentID": "USkeletalMeshComponent_229",
                         "ComponentClass": "USceneComponent",
-                        "ComponentName": "USceneComponent_197",
-                        "ComponentOwner": "ASkeletalMeshActor_196",
-                        "ComponentOwnerClass": "ASkeletalMeshActor",
+                        "ComponentName": "USceneComponent_228",
+                        "ComponentOwner": "AActor_227",
+                        "ComponentOwnerClass": "AActor",
                         "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
                         "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
                         "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
@@ -24,17 +24,17 @@
                 },
                 {
                     "ComponentClass": "USkeletalMeshComponent",
-                    "ComponentID": "USkeletalMeshComponent_198",
+                    "ComponentID": "USkeletalMeshComponent_229",
                     "Properties": {
-                        "AABB_max": "X=-118.225 Y=-69.183 Z=30.356",
-                        "AABB_min": "X=-285.261 Y=-224.499 Z=-41.047",
+                        "AABB_max": "X=17.174 Y=90.257 Z=180.888",
+                        "AABB_min": "X=-14.896 Y=-90.257 Z=-0.035",
                         "AttachParentID": "nullptr",
                         "ComponentClass": "USkeletalMeshComponent",
-                        "ComponentName": "USkeletalMeshComponent_198",
-                        "ComponentOwner": "ASkeletalMeshActor_196",
-                        "ComponentOwnerClass": "ASkeletalMeshActor",
+                        "ComponentName": "USkeletalMeshComponent_229",
+                        "ComponentOwner": "AActor_227",
+                        "ComponentOwnerClass": "AActor",
                         "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
+                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=-0.000",
                         "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
                         "bAutoActive": "true",
                         "bIsActive": "true",
@@ -42,59 +42,119 @@
                     }
                 }
             ],
-            "RootComponentID": "USkeletalMeshComponent_198"
+            "RootComponentID": "USkeletalMeshComponent_229"
         },
         {
-            "ActorClass": "ADirectionalLight",
-            "ActorID": "ADirectionalLight_200",
-            "ActorLabel": "ADirectionalLight200",
+            "ActorClass": "APlayer",
+            "ActorID": "APlayer_297",
+            "ActorLabel": "OBJ_PLAYER_297",
             "ActorTickInEditor": "false",
             "Components": [
                 {
-                    "ComponentClass": "UDirectionalLightComponent",
-                    "ComponentID": "UDirectionalLightComponent_0",
+                    "ComponentClass": "USceneComponent",
+                    "ComponentID": "USceneComponent_298",
                     "Properties": {
-                        "AABB_Max": "X=1.000 Y=1.000 Z=0.100",
-                        "AABB_Min": "X=-1.000 Y=-1.000 Z=-0.100",
-                        "AttachParentID": "UBillboardComponent_0",
-                        "ComponentClass": "UDirectionalLightComponent",
-                        "ComponentName": "UDirectionalLightComponent_0",
-                        "ComponentOwner": "ADirectionalLight_200",
-                        "ComponentOwnerClass": "ADirectionalLight",
-                        "Direction": "X=-1.000 Y=-0.000 Z=-0.000",
-                        "Intensity": "4.000000",
-                        "LightColor": "R=1.000 G=1.000 B=1.000 A=1.000",
+                        "AttachParentID": "nullptr",
+                        "ComponentClass": "USceneComponent",
+                        "ComponentName": "USceneComponent_298",
+                        "ComponentOwner": "APlayer_297",
+                        "ComponentOwnerClass": "APlayer",
                         "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
                         "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
                         "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
                         "bAutoActive": "true",
                         "bIsActive": "true"
                     }
+                }
+            ],
+            "RootComponentID": "USceneComponent_298"
+        },
+        {
+            "ActorClass": "APlayerController",
+            "ActorID": "APlayerController_299",
+            "ActorLabel": "OBJ_PLAYER_CONTROLLER_299",
+            "ActorTickInEditor": "false",
+            "Components": [
+                {
+                    "ComponentClass": "UInputComponent",
+                    "ComponentID": "UInputComponent_300",
+                    "Properties": {
+                        "ComponentClass": "UInputComponent",
+                        "ComponentName": "UInputComponent_300",
+                        "ComponentOwner": "APlayerController_299",
+                        "ComponentOwnerClass": "APlayerController",
+                        "bAutoActive": "true",
+                        "bIsActive": "true"
+                    }
                 },
                 {
-                    "ComponentClass": "UBillboardComponent",
-                    "ComponentID": "UBillboardComponent_0",
+                    "ComponentClass": "USceneComponent",
+                    "ComponentID": "USceneComponent_303",
                     "Properties": {
-                        "AABB_max": "X=0.000 Y=0.000 Z=0.000",
-                        "AABB_min": "X=0.000 Y=0.000 Z=0.000",
                         "AttachParentID": "nullptr",
-                        "BufferKey": "Assets/Editor/Icon/S_LightDirectional.PNG",
-                        "ComponentClass": "UBillboardComponent",
-                        "ComponentName": "UBillboardComponent_0",
-                        "ComponentOwner": "ADirectionalLight_200",
-                        "ComponentOwnerClass": "ADirectionalLight",
-                        "FinalIndexU": "0.000000",
-                        "FinalIndexV": "0.000000",
+                        "ComponentClass": "USceneComponent",
+                        "ComponentName": "USceneComponent_303",
+                        "ComponentOwner": "APlayerController_299",
+                        "ComponentOwnerClass": "APlayerController",
                         "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
-                        "RelativeRotation": "Pitch=45.000 Yaw=45.000 Roll=-0.000",
+                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
                         "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
                         "bAutoActive": "true",
-                        "bIsActive": "true",
-                        "m_Type": "UBillboardComponent"
+                        "bIsActive": "true"
                     }
                 }
             ],
-            "RootComponentID": "UBillboardComponent_0"
+            "RootComponentID": "USceneComponent_303"
+        },
+        {
+            "ActorClass": "APlayerCameraManager",
+            "ActorID": "APlayerCameraManager_301",
+            "ActorLabel": "APlayerCameraManager301",
+            "ActorTickInEditor": "false",
+            "Components": [
+                {
+                    "ComponentClass": "USceneComponent",
+                    "ComponentID": "USceneComponent_302",
+                    "Properties": {
+                        "AttachParentID": "nullptr",
+                        "ComponentClass": "USceneComponent",
+                        "ComponentName": "USceneComponent_302",
+                        "ComponentOwner": "APlayerCameraManager_301",
+                        "ComponentOwnerClass": "APlayerCameraManager",
+                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
+                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
+                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
+                        "bAutoActive": "true",
+                        "bIsActive": "true"
+                    }
+                }
+            ],
+            "RootComponentID": "USceneComponent_302"
+        },
+        {
+            "ActorClass": "AGameMode",
+            "ActorID": "AGameMode_304",
+            "ActorLabel": "OBJ_GAMEMODE_304",
+            "ActorTickInEditor": "false",
+            "Components": [
+                {
+                    "ComponentClass": "USceneComponent",
+                    "ComponentID": "USceneComponent_305",
+                    "Properties": {
+                        "AttachParentID": "nullptr",
+                        "ComponentClass": "USceneComponent",
+                        "ComponentName": "USceneComponent_305",
+                        "ComponentOwner": "AGameMode_304",
+                        "ComponentOwnerClass": "AGameMode",
+                        "RelativeLocation": "X=0.000 Y=0.000 Z=0.000",
+                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
+                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
+                        "bAutoActive": "true",
+                        "bIsActive": "true"
+                    }
+                }
+            ],
+            "RootComponentID": "USceneComponent_305"
         }
     ],
     "NextUUID": 0,


### PR DESCRIPTION
## 주요 변경사항
- `PhysX`를 사용해 `USkeletalMeshComponent`에 rag-doll simulation 구현
    - 스켈레탈 메시의 본(Bone) 구조를 기반으로 `UPhysicsAsset` 내에 `UBodySetup` (물리 바디 정의) 및 `UConstraintSetup` (조인트 정의)을 동적으로 생성합니다.
    - 각 본에 해당하는 `FBodyInstance` (PhysX `PxRigidDynamic` 래퍼) 및 본 간의 연결을 위한 `FConstraintInstance` (PhysX `PxD6Joint` 래퍼)를 생성하여 래그돌을 구성합니다.
- **조인트 로컬 프레임 계산 방식 개선으로 초기 불안정성 해결:**
    - 기존: 스켈레톤 레퍼런스 포즈 기반으로 미리 계산된 로컬 프레임을 사용. 이로 인해 실제 PhysX 액터 생성 시점의 `globalPose`와 불일치가 발생하여, 특히 선형 이동이 잠긴(eLOCKED) 조인트에서 폭발적인 움직임이 나타나는 문제 발생.
    - 변경: `FConstraintInstance::InitConstraint` 시점에, 이미 월드에 배치된 부모 및 자식 PhysX 액터의 실제 `globalPose`를 사용하여 각 액터에 대한 조인트 로컬 프레임(`PLocalFrame_Parent`, `PLocalFrame_Child`)을 동적으로 재계산하도록 수정했습니다.
    - 이를 통해 조인트 생성 시 두 액터의 월드 조인트 프레임이 정확히 일치하도록 하여 초기 불안정성을 크게 줄였습니다.
- **조인트 축(Coordinate System) 보정 기능 추가:**
    - `FConstraintInstance::InitConstraint`에서 자식 액터 기준 로컬 조인트 프레임(`PLocalFrame_Child`)의 회전을 사용자가 정의한 축 보정(예: 새로운 X축 = 기존 Z축 등)을 적용할 수 있도록 수정했습니다.
    - 이는 PhysX D6 조인트의 Twist/Swing 축이 모델링된 본의 로컬 축과 일치하지 않을 경우, 조인트의 기준 축을 원하는 방향으로 정렬하여 Twist 및 Swing 한계가 올바르게 동작하도록 하기 위함입니다. (참고 코드를 기반으로 특정 축 변환 적용)
- **D6 조인트 설정 명확화:**
    - 선형 자유도(X, Y, Z)는 `PxD6Motion::eLOCKED`로 설정하여 일반적인 관절처럼 이동을 고정했습니다.
    - 각도 자유도(Twist, Swing1, Swing2)는 `PxD6Motion::eLIMITED`로 설정하고, `UConstraintSetup`에서 정의된 각도 제한 값을 적용합니다.
    - 연결된 액터 간의 충돌은 기본적으로 비활성화(`PxConstraintFlag::eCOLLISION_ENABLED, false`)하도록 설정했습니다.
    - 조인트 프로젝션(Projection) 관련 파라미터(`ProjectionLinearTolerance`, `ProjectionAngularTolerance`)를 설정하여 조인트 오차 보정을 활성화했습니다.
- **기타 개선:**
    - `USkeletalMeshComponent::CreateRagDollFromPhysicsAsset`에서 `FBodyInstance` 초기화 시 전달하는 `BoneWorldTransform` 계산에 `GetSocketTransform`을 사용하도록 변경하여 코드 간결성 및 일관성을 높였습니다 (단, `GetSocketTransform`이 컴포넌트 공간을 반환할 경우 월드 공간으로의 추가 변환 필요성에 대한 인지 필요).
    - `PxTransform`의 쿼터니언 정규화(`getNormalized()`)를 명시적으로 호출하여 유효성 문제를 방지했습니다.

## 테스트 및 확인 사항

- [x] PVD(PhysX Visual Debugger)를 통해 다음 사항 확인:
    - [x] 각 본에 해당하는 PhysX 액터(캡슐)들이 올바른 크기, 위치, 방향으로 생성되는지.
    - [x] D6 조인트가 올바른 액터 쌍에 연결되는지.
    - [x] 조인트 프레임(특히 자식 액터 기준 로컬 프레임의 X축)이 의도한 Twist/Swing 중심축 방향으로 설정되었는지.
    - [x] Twist 및 Swing 한계 시각화(원뿔/부채꼴)가 새로운 조인트 프레임 기준으로 올바르게 표시되는지.
    - [x] 래그돌 시뮬레이션 시작 시 객체가 폭발하거나 불안정하게 움직이지 않고, 안정적으로 초기 자세를 유지하는지.
- [ ] 다양한 애니메이션 및 외부 힘에 대한 래그돌 반응 테스트.
- [ ] 솔버 반복 횟수(solver iteration counts)가 현재 시스템에 적절하게 설정되어 있는지 확인 (필요시 조정).
